### PR TITLE
chore: .gitignore에 대용량 런타임 산출물 제외 (P1-6①)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ dist/
 web/node_modules/
 web/dist/
 .superpowers/
+
+# Runtime artifacts (LLM 분석 입력 freeze ZIP — api/services/freeze_store.py 가 생성)
+data/freezes/
+
+# Claude Code 로컬 (worktrees, settings.local.json)
+.claude/


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

git은 "이 파일들은 버전 관리에서 제외해라"라는 목록(.gitignore)을 갖고 있습니다. 그런데 시스템이 돌 때마다 자동으로 생기는 대용량 폴더 2개가 이 목록에 빠져 있었습니다:

- `data/freezes/` (106MB) — AI 분석을 할 때마다 "나중에 재현할 수 있게" 입력 자료를 압축 보관하는 폴더. 이미 압축파일 1,212개가 쌓여 있습니다.
- `.claude/` (223MB) — Claude Code 도구가 쓰는 로컬 작업 폴더.

## 왜 위험한가요?

`git add .` 같은 흔한 명령 한 번이면 이 329MB가 통째로 저장소에 커밋됩니다. 한 번 커밋된 대용량 파일은 지워도 저장소 역사에 남아 clone이 영구히 느려집니다. 또 git 상태 화면이 항상 이 폴더들로 어질러져 있어서, 정작 봐야 할 변경사항을 놓치기 쉽습니다.

## 무엇을 고쳤나요?

`.gitignore`에 두 폴더를 제외 대상으로 추가했습니다 (주석 포함 6줄). 각 폴더가 왜 생기는지 출처도 주석으로 남겼습니다.

## 어떻게 검증했나요?

- 추가 전 `.gitignore`에 두 항목이 없음을 확인 (grep)
- 폴더 크기 실측 (du: 106MB / 223MB)
- 코드 변경이 아니므로 테스트 영향 없음

## 참고

- 이미 커밋된 파일에는 영향 없습니다 (.gitignore는 새로 추가되는 것만 막음).
- `data/freezes/` 안의 기존 보관물은 그대로 디스크에 남습니다 — 90일 정리 정책(freeze_cleanup) 등재는 별도 PR로 올라갑니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)