### PR TITLE
fix: 일주일 내내 거래정지된 종목의 주봉 데이터 오염 차단 (P2)

### DIFF
--- a/kr_pipeline/weekly/transform.py
+++ b/kr_pipeline/weekly/transform.py
@@ -74,7 +74,16 @@ def drop_incomplete_weeks(weekly: pd.DataFrame, today: date) -> pd.DataFrame:
 
 
 def to_weekly_rows(ticker: str, weekly: pd.DataFrame) -> list[tuple]:
-    """weekly_prices.executemany 용 tuple 리스트."""
+    """weekly_prices.executemany 용 tuple 리스트.
+
+    adj_* 는 NaN→None 변환 (daily 의 ohlcv/transform._adj 와 동일 처리).
+    한 주 전체 halt(일봉 adj_* 전부 NULL)면 집계가 NaN — 무변환 시 psycopg 가
+    'NaN'::numeric 으로 적재해 COALESCE(adj_*, raw) 를 통과, payload JSON 오염.
+    raw OHLCV 는 NOT NULL(halt 마커 0/유지값)이라 그대로.
+    """
+    def _adj(v):
+        return None if pd.isna(v) else float(v)
+
     return [
         (
             ticker,
@@ -83,11 +92,11 @@ def to_weekly_rows(ticker: str, weekly: pd.DataFrame) -> list[tuple]:
             int(r["high"]),
             int(r["low"]),
             int(r["close"]),
-            float(r["adj_close"]),
-            float(r["adj_high"]),
-            float(r["adj_low"]),
-            float(r["adj_open"]),
-            float(r["adj_volume"]),
+            _adj(r["adj_close"]),
+            _adj(r["adj_high"]),
+            _adj(r["adj_low"]),
+            _adj(r["adj_open"]),
+            _adj(r["adj_volume"]),
             int(r["volume"]),
             int(r["value"]),
             int(r["trading_days"]),

--- a/tests/test_weekly_transform.py
+++ b/tests/test_weekly_transform.py
@@ -322,3 +322,62 @@ def test_to_weekly_index_rows_preserves_decimals():
     }])
     rows = to_weekly_index_rows("2001", weekly)
     assert rows == [("2001", date(2026, 6, 5), 901.23, 905.67, 898.41, 903.89, 1000, 5000, 5)]
+
+
+# ====== P2: 전주 거래정지 주의 adj_* NaN → NULL (P1-5 계열 데이터 정합) ======
+
+def test_to_weekly_rows_full_halt_week_adj_nan_becomes_none():
+    """한 주 전체가 거래정지(일봉 adj_* 전부 NULL)면 주봉 adj_* 는 NULL 이어야 한다.
+
+    기존엔 float(NaN) 이 그대로 통과해 psycopg 가 'NaN'::numeric 으로 적재 —
+    COALESCE(adj_high, high) 가 NaN 을 NULL 로 안 보고 통과시켜 payload JSON
+    오염(invalid JSON) 경로. daily 의 _adj()(ohlcv/transform.py) 와 동일 처리.
+    """
+    import math
+    import pandas as pd
+    from kr_pipeline.weekly.transform import aggregate_to_weekly, to_weekly_rows
+
+    daily = pd.DataFrame([
+        # 월~수 3일 전부 halt: raw 는 0/유지값(NOT NULL), adj_* 는 NULL(NaN)
+        {"date": "2026-06-01", "open": 0, "high": 0, "low": 0, "close": 1000,
+         "adj_close": float("nan"), "adj_high": float("nan"), "adj_low": float("nan"),
+         "adj_open": float("nan"), "adj_volume": float("nan"), "volume": 0, "value": 0},
+        {"date": "2026-06-02", "open": 0, "high": 0, "low": 0, "close": 1000,
+         "adj_close": float("nan"), "adj_high": float("nan"), "adj_low": float("nan"),
+         "adj_open": float("nan"), "adj_volume": float("nan"), "volume": 0, "value": 0},
+        {"date": "2026-06-03", "open": 0, "high": 0, "low": 0, "close": 1000,
+         "adj_close": float("nan"), "adj_high": float("nan"), "adj_low": float("nan"),
+         "adj_open": float("nan"), "adj_volume": float("nan"), "volume": 0, "value": 0},
+    ])
+    weekly = aggregate_to_weekly(daily)
+    assert len(weekly) == 1
+    rows = to_weekly_rows("HALT1", weekly)
+    (_, _, o, h, lo, c, adj_c, adj_h, adj_l, adj_o, adj_v, vol, val, td) = rows[0]
+    # raw 는 그대로 (halt 마커 0/유지값)
+    assert (o, h, lo, c) == (0, 0, 0, 1000) and td == 3
+    # adj_* 는 NaN 이 아니라 None — 'NaN'::numeric 적재 차단
+    for name, v in [("adj_close", adj_c), ("adj_high", adj_h), ("adj_low", adj_l),
+                    ("adj_open", adj_o), ("adj_volume", adj_v)]:
+        assert v is None, f"{name}={v!r} — NaN 이 NULL 로 변환되지 않음"
+        assert not (isinstance(v, float) and math.isnan(v))
+
+
+def test_to_weekly_rows_partial_halt_week_keeps_values():
+    """주 중 일부만 halt 면 pandas 집계(first/last/max/min 의 NaN skip)가
+    유효값을 쓰므로 adj_* 는 값 유지 — 기존 동작 보존."""
+    import pandas as pd
+    from kr_pipeline.weekly.transform import aggregate_to_weekly, to_weekly_rows
+
+    daily = pd.DataFrame([
+        {"date": "2026-06-08", "open": 100, "high": 110, "low": 95, "close": 105,
+         "adj_close": 105.0, "adj_high": 110.0, "adj_low": 95.0,
+         "adj_open": 100.0, "adj_volume": 5000.0, "volume": 5000, "value": 500000},
+        {"date": "2026-06-09", "open": 0, "high": 0, "low": 0, "close": 105,
+         "adj_close": float("nan"), "adj_high": float("nan"), "adj_low": float("nan"),
+         "adj_open": float("nan"), "adj_volume": float("nan"), "volume": 0, "value": 0},
+    ])
+    weekly = aggregate_to_weekly(daily)
+    rows = to_weekly_rows("HALT2", weekly)
+    (_, _, _, _, _, _, adj_c, adj_h, adj_l, adj_o, adj_v, _, _, _) = rows[0]
+    assert adj_c == 105.0 and adj_h == 110.0 and adj_l == 95.0 and adj_o == 100.0
+    assert adj_v == 5000.0


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

일봉(하루 단위 가격)을 주봉(일주일 단위 가격)으로 합칠 때의 이야기입니다. 거래정지된 날의 "수정 가격"은 비어 있음(NULL)으로 저장되는데, **일주일 내내 거래정지**였던 종목은 그 주의 수정 가격 계산 결과가 "숫자 아님(NaN)"이라는 특수값이 됩니다. 지금 코드는 이 NaN을 검사 없이 DB에 그대로 넣습니다.

같은 파일 안의 지수(코스피 등) 처리 코드는 이미 올바르게 NaN을 비움(NULL)으로 바꾸고 있었는데, 종목 처리 코드만 이 방어가 빠져 있었습니다.

## 왜 위험한가요?

DB의 "값이 비어 있으면 원본 가격을 대신 써라"(COALESCE) 로직이 NaN을 "비어 있음"으로 인식하지 못합니다. 그래서 NaN이 원본 대체 없이 그대로 흘러가고, 최종적으로 AI에게 주는 JSON 자료에 NaN이 섞이면 **JSON 형식 자체가 깨질 수 있습니다**. 현재 DB에는 아직 해당 데이터가 0건이라 터지기 전에 막는 수정입니다.

## 무엇을 고쳤나요?

주봉 변환 함수에 "NaN이면 비움(NULL)으로 바꿔라" 3줄짜리 변환기를 추가했습니다 — 일봉 처리 코드에 이미 있는 것과 똑같은 방식입니다. 일부만 정지였던 주는 정상 값이 계산되므로 기존 동작이 그대로 유지됩니다(테스트로 고정).

## 어떻게 검증했나요?

- TDD: "일주일 전부 정지" 시나리오 테스트가 먼저 실패(NaN 통과)하는 것을 확인 후 수정 → 통과
- "일부만 정지" 시나리오는 수정 전후 동일하게 통과 (기존 동작 보존 증명)
- 전체 테스트: 23 failed(사전 존재 baseline 24 이하) / 802 passed

## 참고

- production DB 재정리(기존 데이터 수정)는 불필요 — 현재 오염 행 0건 실측.
- 리뷰 포인트: `_adj()` 적용 대상이 수정가격 5개 필드뿐이고 원본 가격(NOT NULL)은 건드리지 않는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)