### PR TITLE
fix: 거래량 비율 0이 '데이터 없음'으로 잘못 표시되던 API 버그 (P2)

### DIFF
--- a/api/routers/indicators.py
+++ b/api/routers/indicators.py
@@ -175,7 +175,8 @@ def get_minervini_passed(date_: date | None = None, min_rs: int = 70, limit: int
         rows = cur.fetchall()
     return [MinerviniPassedOut(
         ticker=r[0], name=r[1], sector=r[2], rs_rating=r[3], adj_close=float(r[4]),
-        volume_ratio_50d=float(r[5]) if r[5] else None,
+        # Decimal('0') 을 None 으로 오변환 금지 (signals.py 선례) — 0 = 무거래일, None = 데이터 없음
+        volume_ratio_50d=float(r[5]) if r[5] is not None else None,
         pocket_pivot_flag=r[6],
     ) for r in rows]
 
@@ -206,7 +207,8 @@ def get_by_sector(
         rows = cur.fetchall()
     return [SectorStockOut(
         ticker=r[0], name=r[1], sector=r[2], market=r[3], rs_rating=r[4], adj_close=float(r[5]),
-        volume_ratio_50d=float(r[6]) if r[6] else None,
+        # Decimal('0') 을 None 으로 오변환 금지 (signals.py 선례)
+        volume_ratio_50d=float(r[6]) if r[6] is not None else None,
         pocket_pivot_flag=r[7],
         minervini_pass=bool(r[8]) if r[8] is not None else False,
     ) for r in rows]

--- a/tests/test_api_indicators_by_sector.py
+++ b/tests/test_api_indicators_by_sector.py
@@ -84,3 +84,48 @@ def test_by_sector_respects_limit(client):
     r = client.get("/api/indicators/by-sector?sector=금융&limit=5")
     assert r.status_code == 200
     assert len(r.json()) <= 5
+
+
+def test_volume_ratio_zero_is_not_none(client, db):
+    """P2: volume_ratio_50d = 0(무거래일)이 None('데이터 없음')으로 위장되면 안 된다.
+
+    `if r[n] else None` 은 Decimal('0') 을 falsy 로 오변환 — signals.py 는
+    이미 `is not None` 으로 고쳐진 선례(주석 포함)가 있는데 indicators 2곳에
+    옛 패턴이 잔존.
+    """
+    def override_get_conn():
+        yield db
+    app.dependency_overrides[get_conn] = override_get_conn
+    try:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_indicators WHERE ticker LIKE 'VRZ%'")
+            cur.execute("DELETE FROM stocks WHERE ticker LIKE 'VRZ%'")
+            cur.execute(
+                "INSERT INTO stocks (ticker, name, market, sector) "
+                "VALUES ('VRZ01','무거래','KOSPI','테스트섹터VRZ')"
+            )
+            cur.execute(
+                """INSERT INTO daily_indicators
+                     (ticker, date, adj_close, rs_rating, minervini_pass, volume_ratio_50d)
+                   VALUES ('VRZ01','2026-05-15',1000.0, 95, TRUE, 0)"""
+            )
+        db.commit()
+
+        # by-sector 경로
+        r = client.get("/api/indicators/by-sector?sector=테스트섹터VRZ&date_=2026-05-15&limit=10")
+        assert r.status_code == 200
+        row = next(x for x in r.json() if x["ticker"] == "VRZ01")
+        assert row["volume_ratio_50d"] == 0.0, f"0 이 None 으로 위장: {row['volume_ratio_50d']!r}"
+
+        # minervini-passed 경로
+        r2 = client.get("/api/indicators/minervini-passed?date_=2026-05-15&min_rs=70&limit=500")
+        assert r2.status_code == 200
+        row2 = next((x for x in r2.json() if x["ticker"] == "VRZ01"), None)
+        assert row2 is not None, "seed 종목이 minervini-passed 응답에 없음"
+        assert row2["volume_ratio_50d"] == 0.0, f"0 이 None 으로 위장: {row2['volume_ratio_50d']!r}"
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_indicators WHERE ticker LIKE 'VRZ%'")
+            cur.execute("DELETE FROM stocks WHERE ticker LIKE 'VRZ%'")
+        db.commit()
+        app.dependency_overrides.pop(get_conn, None)


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

웹 화면에 종목의 "거래량 비율"(오늘 거래량이 평소의 몇 배인지)을 보여주는 API가 있습니다. 그런데 코드가 "값이 비어 있으면(없으면) 빈 값으로 표시해라"를 구현하면서 파이썬의 느슨한 참/거짓 판정(`if 값`)을 썼습니다. 문제는 숫자 **0도 '거짓'으로 판정**된다는 것 — 그래서 거래량 비율이 정확히 0인 날(무거래일)이 "데이터 없음"으로 둔갑했습니다.

## 왜 위험한가요?

"비율 0"(거래가 전혀 없었다 — 의미 있는 정보)과 "데이터 없음"(계산을 못 했다)은 완전히 다른 상태인데 화면에서 구분이 불가능해집니다. 거래정지 종목을 보고 있는 사용자가 오해할 수 있습니다.

## 무엇을 고쳤나요?

두 곳의 판정을 `if 값` → `if 값 is not None`(비어 있을 때만 빈 값)으로 바꿨습니다. 사실 같은 버그가 다른 파일(signals.py)에서 이미 발견·수정된 적이 있고 수정 주석까지 남아 있었는데, 이 두 곳에만 옛 패턴이 남아 있던 것입니다. API 전체를 훑어 숫자형은 이 2곳뿐임을 확인했습니다(날짜형 3곳은 이 문제가 성립하지 않아 그대로).

## 어떻게 검증했나요?

- TDD: 비율 0인 종목을 심어 두 엔드포인트가 None이 아닌 0.0을 반환하는지 검사 — 수정 전 실패, 수정 후 통과
- 전체 테스트: 24 failed(사전 존재 baseline 그대로) / 800 passed

## 참고

- 리뷰 포인트: 판정 변경이 `volume_ratio_50d` 두 곳뿐이고 다른 필드는 건드리지 않았는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)