### PR TITLE
fix: 시장 상태 계산에서 하루 오류가 나머지 날짜 전체를 무너뜨리던 문제 (P2)

### DIFF
--- a/kr_pipeline/market_context/modes.py
+++ b/kr_pipeline/market_context/modes.py
@@ -296,6 +296,10 @@ def run(
                             rows_to_upsert.append(result)
                     except Exception as e:
                         failures.append((f"{index_code}@{target_date}", str(e)))
+                        # DB 예외의 aborted 트랜잭션이 잔여 날짜로 연쇄되지 않게
+                        # (weekly/indicators 종목 루프와 동일 패턴). rows_to_upsert 는
+                        # 파이썬 객체라 rollback 에 유실되지 않는다.
+                        conn.rollback()
 
                 if rows_to_upsert:
                     rows_total += upsert_market_context(conn, rows_to_upsert)

--- a/tests/test_market_context_modes.py
+++ b/tests/test_market_context_modes.py
@@ -43,3 +43,47 @@ def test_backfill_uses_db_min(monkeypatch):
         load_start, load_end, upsert_start = compute_date_range(Mode.BACKFILL, conn=None)
     assert load_start == date(2024, 1, 2)
     assert upsert_start == date(2024, 1, 2)
+
+
+def test_per_date_db_error_does_not_cascade(db, monkeypatch):
+    """P2: 날짜 1건의 DB 예외가 rollback 없이 aborted 트랜잭션으로 남아
+    잔여 날짜 전부를 InFailedSqlTransaction 연쇄 실패시키면 안 된다.
+
+    (weekly/indicators 의 종목 루프는 except 에서 rollback — 여기만 비대칭)
+    """
+    from datetime import date as _date
+    import pandas as pd
+    from kr_pipeline.market_context import modes
+
+    dates = [_date(2026, 6, 1), _date(2026, 6, 2), _date(2026, 6, 3)]
+    df = pd.DataFrame({"date": dates})
+
+    monkeypatch.setattr(
+        modes, "compute_date_range",
+        lambda mode, window_days=30, conn=None: (dates[0], dates[-1], dates[0]),
+    )
+    monkeypatch.setattr(
+        modes, "load_index_daily_with_sma200",
+        lambda conn, code, s, e: df if code == "1001" else pd.DataFrame(),
+    )
+
+    ok_calls: list = []
+
+    def fake_process(conn, target_date, index_code, market, idx_df):
+        if target_date == dates[0]:
+            # 실제 DB 예외로 트랜잭션을 aborted 상태로 만든 뒤 전파
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1/0")
+            return None  # unreachable
+        # rollback 이 됐다면 이 쿼리는 성공해야 한다
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1")
+        ok_calls.append(target_date)
+        return None
+
+    monkeypatch.setattr(modes, "_process_one_date", fake_process)
+
+    stats = modes.run(db, modes.Mode.INCREMENTAL)
+
+    assert len(ok_calls) == 2, f"잔여 날짜가 연쇄 실패 (처리 성공: {ok_calls})"
+    assert len(stats.failures) == 1, f"1건만 실패해야 하는데: {stats.failures}"


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

시장 전체 상태(상승장/하락장)를 날짜별로 계산하는 루프가 있습니다. 어느 하루 계산에서 DB 오류가 나면 그 날짜만 실패 처리하고 다음 날짜로 넘어가야 하는데, **오류 뒷정리(rollback)를 빼먹었습니다**. PostgreSQL은 "오류가 정리되지 않은 상태"에서는 새 작업을 전부 거부하므로, 하루의 오류가 도미노처럼 그 뒤 모든 날짜를 함께 실패시켰습니다.

## 왜 위험한가요?

예를 들어 30일치 재계산 중 3일째에 일시적 DB 오류가 나면, 남은 27일치가 전부 실패하고 — 더 나쁘게는 그때까지 계산해 둔 결과의 저장까지 통째로 유실됩니다. 시장 상태는 AI 판단의 참고 입력이라, 빠진 날짜가 생기면 그날들의 판단 품질에 영향을 줍니다.

## 무엇을 고쳤나요?

오류 처리 지점에 뒷정리(rollback) 한 줄을 추가했습니다. 사실 같은 코드베이스의 다른 루프들(주봉·지표 계산)은 전부 이 뒷정리를 하고 있었고, 이 파일만 빠져 있던 비대칭이었습니다. 계산해 둔 결과는 파이썬 메모리에 있어서 뒷정리로 사라지지 않는다는 것도 주석으로 명시했습니다.

## 어떻게 검증했나요?

- TDD: 진짜 DB 오류(0으로 나누기)로 "오류 미정리 상태"를 만든 뒤, 수정 전에는 3일치가 전부 실패(연쇄)하고 수정 후에는 해당 1일만 실패하는 것을 확인
- market_context 테스트 22개 전부 통과, 전체 테스트 23 failed(사전 존재 baseline 24 이하) / 801 passed

## 참고

- 어제 머지된 P1-4(신선도 수정)와 같은 파일이지만 다른 지점입니다 — 충돌 없이 겹치지 않는 라인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)