### PR TITLE
feat: 파이프라인 실행 상세에서 안 보이던 정보 2가지 표시 (P2)

### DIFF
--- a/web/src/pages/PipelinePage.tsx
+++ b/web/src/pages/PipelinePage.tsx
@@ -39,7 +39,22 @@ const SUB_STEP_FIELD_LABELS: Record<string, string> = {
   backfilled: "갱신",
   count: "건수",
   rows_affected: "rows",
+  abort_skipped: "abort 자가리셋 스킵",
+  market_base_missing: "시장 기준 누락",
+  integrity_skipped: "무결성 스킵",
 };
+
+// 배열/객체 값이 "[object Object]" 로 뭉개지지 않게 사람이 읽을 형태로.
+// 배열(예: market_base_missing 종목 목록) → "N건 (앞 5개 …)".
+function formatDetailValue(v: unknown): string {
+  if (Array.isArray(v)) {
+    if (v.length === 0) return "0건";
+    const head = v.slice(0, 5).map((x) => (typeof x === "object" ? JSON.stringify(x) : String(x)));
+    return `${v.length}건 (${head.join(", ")}${v.length > 5 ? " …" : ""})`;
+  }
+  if (v !== null && typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
 
 function StatusChip({ status }: { status: string }) {
   if (status === "success")
@@ -387,7 +402,7 @@ export default function PipelinePage() {
                                   : {};
                                 const parts = Object.entries(fields)
                                   .filter(([k]) => k !== "failed_tickers")
-                                  .map(([k, v]) => `${SUB_STEP_FIELD_LABELS[k] ?? k} ${v}`);
+                                  .map(([k, v]) => `${SUB_STEP_FIELD_LABELS[k] ?? k} ${formatDetailValue(v)}`);
                                 return (
                                   <li key={stepKey} className="text-data text-ink">
                                     <span className="font-semibold">{label}:</span>{" "}


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

파이프라인 실행 기록 화면(러너 상세)이 있습니다. 백엔드는 실행 결과에 유용한 정보 두 가지를 이미 담아 보내고 있었는데, 화면이 이를 제대로 보여주지 못했습니다:

1. **시장 기준 누락 목록** — 성과 계산 때 "시장 대비 수익률"의 기준 데이터가 없던 종목들. 배열(목록)인데 화면 코드가 목록을 문자열로 뭉개서 "[object Object]" 같은 깨진 표기로 나왔습니다.
2. **abort 자가리셋 스킵 수** — "이 종목은 포기" 판정 후 재분류 전까지 재평가를 건너뛴 종목 수. 한글 라벨 사전에 등록이 안 돼 영문 키가 그대로 노출됐습니다.

## 왜 위험한가요?

위험이라기보다 관측성 문제입니다 — 운영자가 "성과 계산에서 뭐가 빠졌는지", "왜 이 종목이 재평가가 안 됐는지"를 화면에서 확인할 수 없어서, 로그를 직접 뒤져야 했습니다.

## 무엇을 고쳤나요?

- 한글 라벨 3개 추가 (abort 스킵, 시장 기준 누락, 무결성 스킵)
- 값 표시기(formatDetailValue) 추가: 목록이면 "N건 (앞 5개 …)"로, 복잡한 값이면 JSON으로 — 어떤 형태의 값이 와도 깨진 표기가 안 나오게

## 어떻게 검증했나요?

- TypeScript 타입 검사(tsc --noEmit) 통과 — 웹은 단위 테스트가 없는 프로젝트 관례라 타입 검사가 기준
- 백엔드/파이썬 코드는 무변경 (전체 pytest 영향 없음)

## 참고

- 스텝 내부 failed_tickers 숨김은 기존 동작 그대로 유지했습니다(주말 분류용 전용 뷰가 이미 실패 종목을 보여줌) — 스코프 최소화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)