### PR TITLE
feat(freeze): freeze_cleanup 을 pipeline_specs 에 등재 — retention 90일 스케줄 편입

### DIFF
--- a/kr_pipeline/llm_runner/freeze_cleanup.py
+++ b/kr_pipeline/llm_runner/freeze_cleanup.py
@@ -126,6 +126,24 @@ def cleanup(
     return CleanupResult(candidates=candidates, deleted=deleted, bytes_freed=bytes_freed)
 
 
+def run_cli(conn: Connection, *, apply: bool, retention_days: int) -> CleanupResult:
+    """CLI 진입점 — pipeline_runs 에 run 기록 후 cleanup 실행.
+
+    pipeline_specs 등재(pipeline_db_name='freeze_cleanup') 계약: UI 실행 가시화
+    (wait_for_run_registration)·중복 방지(check_can_run_pipeline)가 이 행에 의존.
+    """
+    from kr_pipeline.db.runs import run_tracking
+
+    mode = "apply" if apply else "dry-run"
+    with run_tracking(
+        conn, pipeline="freeze_cleanup", mode=mode, params={"days": retention_days}
+    ) as state:
+        result = cleanup(conn, dry_run=not apply, retention_days=retention_days)
+        state["rows_affected"] = result.deleted
+        state["total_count"] = result.candidates
+    return result
+
+
 if __name__ == "__main__":
     import argparse
     from dotenv import load_dotenv
@@ -141,5 +159,5 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
     with connect() as conn:
-        result = cleanup(conn, dry_run=not args.apply, retention_days=args.days)
+        result = run_cli(conn, apply=args.apply, retention_days=args.days)
     print(f"candidates={result.candidates} deleted={result.deleted} bytes_freed={result.bytes_freed}")

--- a/kr_pipeline/llm_runner/pipeline_specs.py
+++ b/kr_pipeline/llm_runner/pipeline_specs.py
@@ -10,6 +10,9 @@ frontend / backend 양쪽이 참조하는 단일 진실. 각 pipeline 의:
                        (pipeline_runs.mode 가 이 prefix 로 시작하는 행만 매치)
   - modes: 실행 모드 리스트 [{id, label, args}]
   - default_cron: cron 표현식
+  - cron_mode (옵션): cron 라인에 쓸 mode id. 없으면 modes[0].
+                     (UI 기본 모드는 안전한 dry-run, cron 은 실제 실행이
+                      필요한 파이프라인용 — freeze-cleanup)
 """
 from __future__ import annotations
 
@@ -285,6 +288,28 @@ PIPELINE_SPECS: list[dict] = [
         "outputs": ["classification_backfill"],
         "depends_on": ["indicators-daily", "indicators-weekly", "market-context", "ohlcv"],
     },
+    {
+        "id": "freeze-cleanup",
+        "group": "llm",
+        "label": "Freeze 정리 (retention)",
+        "description": "classification freeze 아티팩트 retention — 90일 경과 + 비활성 종목 + stage 별 최신 제외분을 삭제해 디스크 회수.",
+        "module": "kr_pipeline.llm_runner.freeze_cleanup",
+        "pipeline_db_name": "freeze_cleanup",
+        "modes": [
+            {"id": "dry-run", "label": "미리보기 (dry-run)",
+             "args": [], "is_heavy": False},
+            {"id": "apply", "label": "실제 삭제", "args": ["--apply"], "is_heavy": True,
+             "params": [{"name": "days", "label": "보존 기간(일)", "type": "int",
+                         "default": 90, "min": 30, "max": 365}]},
+        ],
+        "default_cron": "40 4 * * 6",
+        "cron_mode": "apply",
+        "schedule_label": "주 1회 (토)",
+        "long_description": "LLM 분류 시 저장되는 freeze 아티팩트(zip)를 정리해 디스크를 회수합니다.\n\n삭제 조건 (모두 충족해야 삭제):\n- frozen_at 이 보존 기간(기본 90일) 경과\n- 그 종목의 최신 weekly_classification 이 entry/watch 가 아님 (활성 종목 보호)\n- (종목, stage) 그룹의 최신 freeze 는 classification 무관하게 항상 보존\n\n미리보기(dry-run)는 삭제 후보 수만 계산하고, 실제 삭제(--apply)는 아티팩트 파일 삭제 + DB 행 삭제를 함께 수행합니다. LLM 호출 없음.\n\ncron 은 실제 삭제(--apply) 로 등록됩니다 — dry-run cron 은 retention 을 수행하지 않아 무의미하기 때문. UI 기본 모드는 안전한 미리보기입니다.\n\n선행 작업: llm-full-daily, llm-weekend (freeze 생성 주체)\n후속 작업: 없음",
+        "inputs": ["classification_freezes", "weekly_classification"],
+        "outputs": ["classification_freezes"],
+        "depends_on": ["llm-full-daily", "llm-weekend"],
+    },
 ]
 
 
@@ -315,14 +340,18 @@ def matches_mode_prefix(mode: str | None, prefix: str | None) -> bool:
 
 
 def get_default_cron_lines() -> list[str]:
-    """PIPELINE_SPECS 의 default_cron + 첫 번째 mode args 로 cron 라인 생성."""
+    """PIPELINE_SPECS 의 default_cron + cron_mode(없으면 첫 번째 mode) args 로 cron 라인 생성."""
     from pathlib import Path
     project_dir = Path(__file__).parent.parent.parent.resolve()
     lines = []
     for spec in PIPELINE_SPECS:
         if not spec.get("default_cron"):
             continue  # 수동 전용 파이프라인(빈 cron)은 등록 안 함
-        default_mode = spec["modes"][0]
+        cron_mode_id = spec.get("cron_mode")
+        if cron_mode_id:
+            default_mode = next(m for m in spec["modes"] if m["id"] == cron_mode_id)
+        else:
+            default_mode = spec["modes"][0]
         args_str = " ".join(default_mode["args"])
         cmd = f"uv run python -m {spec['module']}"
         if args_str:

--- a/tests/test_cron_manager.py
+++ b/tests/test_cron_manager.py
@@ -105,18 +105,19 @@ def test_diff_managed_block_shows_changes():
 
 def test_default_cron_lines_contains_three_modes():
     """default cron 라인에 LLM 3종 (full-daily, weekend, performance) + 통합 체인 2종 포함 확인.
-    P1a 이후 예약 spec 8개: universe, corporate-actions, data-daily, data-weekly,
-    market-context, llm-full-daily, llm-weekend, llm-performance.
+    예약 spec 9개: universe, corporate-actions, data-daily, data-weekly,
+    market-context, llm-full-daily, llm-weekend, llm-performance, freeze-cleanup.
     (기존 ohlcv/weekly/indicators-daily/indicators-weekly 는 비예약(cron="")으로 제외, llm-backfill 도 제외.)
     """
     from kr_pipeline.llm_runner.cron_manager import DEFAULT_CRON_LINES
 
-    assert len(DEFAULT_CRON_LINES) == 8
+    assert len(DEFAULT_CRON_LINES) == 9
     assert any("full-daily" in line for line in DEFAULT_CRON_LINES)
     assert any("weekend" in line for line in DEFAULT_CRON_LINES)
     assert any("performance" in line for line in DEFAULT_CRON_LINES)
     assert any("--chain=daily" in line for line in DEFAULT_CRON_LINES)
     assert any("--chain=weekly" in line for line in DEFAULT_CRON_LINES)
+    assert any("freeze_cleanup" in line for line in DEFAULT_CRON_LINES)
 
 
 def test_register_and_unregister_flow(monkeypatch, tmp_path):

--- a/tests/test_freeze_cleanup.py
+++ b/tests/test_freeze_cleanup.py
@@ -300,3 +300,31 @@ def test_active_protection_uses_analyzed_for_date(db):
             cur.execute("DELETE FROM classification_freezes WHERE ticker=%s", (sym,))
             cur.execute("DELETE FROM weekly_classification WHERE symbol=%s", (sym,))
         db.commit()
+
+
+def test_run_cli_records_pipeline_run(db):
+    """CLI 진입점은 pipeline_runs 에 run 을 기록한다 (pipeline_specs 등재 계약).
+
+    spec 의 pipeline_db_name='freeze_cleanup' 이 실재하려면 — UI 실행 가시화
+    (wait_for_run_registration)·중복 방지(check_can_run_pipeline)가 이 행에 의존.
+    """
+    from kr_pipeline.llm_runner.freeze_cleanup import run_cli
+
+    try:
+        result = run_cli(db, apply=False, retention_days=90)
+        assert result.deleted == 0  # dry-run 은 삭제 없음
+        with db.cursor() as cur:
+            cur.execute(
+                """SELECT mode, status, params FROM pipeline_runs
+                    WHERE pipeline = 'freeze_cleanup' ORDER BY id DESC LIMIT 1"""
+            )
+            row = cur.fetchone()
+        assert row is not None, "pipeline_runs 에 freeze_cleanup 행이 없음"
+        mode, status, params = row
+        assert mode == "dry-run"
+        assert status == "success"
+        assert params["days"] == 90
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM pipeline_runs WHERE pipeline = 'freeze_cleanup'")
+        db.commit()

--- a/tests/test_pipeline_specs.py
+++ b/tests/test_pipeline_specs.py
@@ -16,7 +16,7 @@ def test_pipeline_specs_has_all_modules():
         "universe", "ohlcv", "weekly", "corporate-actions",
         "indicators-daily", "indicators-weekly", "market-context",
         "llm-full-daily", "llm-weekend", "llm-performance",
-        "llm-backfill",
+        "llm-backfill", "freeze-cleanup",
         "data-daily", "data-weekly",
     }
     assert required.issubset(ids), f"missing: {required - ids}"
@@ -271,3 +271,39 @@ def test_corporate_actions_scheduled_weekday_daily():
     ca = get_spec("corporate-actions")
     assert ca["default_cron"] == "0 8 * * 1-5"
     assert ca["schedule_label"] == "평일 매일"
+
+
+def test_freeze_cleanup_spec_registered():
+    """freeze retention 이 스케줄 체계에 등재 — UI 기본(modes[0])은 dry-run."""
+    from kr_pipeline.llm_runner.pipeline_specs import get_spec
+
+    s = get_spec("freeze-cleanup")
+    assert s is not None
+    assert s["module"] == "kr_pipeline.llm_runner.freeze_cleanup"
+    assert s["pipeline_db_name"] == "freeze_cleanup"
+    assert s["group"] == "llm"
+    # RunDialog 는 modes[0] 을 기본 선택 — 파괴적 모드가 기본이면 안 됨
+    assert s["modes"][0]["id"] == "dry-run"
+    assert s["modes"][0]["is_heavy"] is False
+    assert "--apply" not in s["modes"][0]["args"]
+    apply_mode = next(m for m in s["modes"] if m["id"] == "apply")
+    assert apply_mode["is_heavy"] is True
+    assert "--apply" in apply_mode["args"]
+
+
+def test_freeze_cleanup_cron_line_uses_apply():
+    """cron 라인은 --apply 여야 retention 이 실제 실행된다 (cron_mode 키)."""
+    from kr_pipeline.llm_runner.pipeline_specs import get_default_cron_lines
+
+    lines = [ln for ln in get_default_cron_lines() if "freeze_cleanup" in ln]
+    assert len(lines) == 1
+    assert "--apply" in lines[0]
+    assert lines[0].startswith("40 4 * * 6")
+
+
+def test_cron_mode_absent_falls_back_to_first_mode():
+    """cron_mode 없는 기존 spec 은 modes[0] args 그대로 (llm-full-daily = dry-run 유지)."""
+    from kr_pipeline.llm_runner.pipeline_specs import get_default_cron_lines
+
+    line = next(ln for ln in get_default_cron_lines() if "--mode=full-daily" in ln)
+    assert "--dry-run" in line


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

LLM 이 종목을 분류할 때마다 그 순간의 입력 데이터를 zip 파일(freeze)로 저장합니다. 이 파일을 90일 뒤에 지워주는 청소기(`freeze_cleanup.py`)는 이미 만들어져 있었는데, **청소기를 스케줄표(`pipeline_specs.py`)에 올리는 걸 빼먹어서** 아무도 이 청소기를 돌리지 않는 상태였습니다. 결과적으로 zip 파일이 지워지지 않고 계속 쌓입니다.

## 왜 위험한가요?

freeze 는 분류 1건당 1개씩 생기므로, 평일 분석 + 주말 전체 분류가 돌수록 디스크가 무한히 커집니다. 몇 달 뒤 디스크가 가득 차면 청소기와 무관한 파이프라인(가격 적재, 지표 계산)까지 연쇄로 실패할 수 있습니다.

## 무엇을 고쳤나요?

- `kr_pipeline/llm_runner/pipeline_specs.py` — 스케줄표에 `freeze-cleanup` 항목 추가 (토요일 04:40, 주말 데이터·분류 작업이 끝난 뒤). 모드 2개: **미리보기(dry-run, UI 기본)** 와 **실제 삭제(--apply)**.
- `kr_pipeline/llm_runner/pipeline_specs.py` — `cron_mode` 옵션 키 신설: cron 에는 실제 삭제 모드를 쓰되, 웹 UI 의 기본 버튼은 안전한 미리보기가 되도록 분리했습니다. 이 키가 없는 기존 파이프라인은 동작이 전혀 바뀌지 않습니다 (테스트로 고정).
- `kr_pipeline/llm_runner/freeze_cleanup.py` — CLI 실행을 `run_tracking` 으로 감싸 `pipeline_runs` 테이블에 실행 기록을 남기도록 했습니다. 스케줄표의 다른 작업들과 똑같이, 웹 UI 에서 '실행 중/성공/실패' 가 보이고 같은 날 중복 실행이 방지됩니다.

## 어떻게 검증했나요?

- TDD: 테스트 4건을 먼저 작성해 red 확인 → 구현 → green (spec 등재, cron 라인이 --apply 인지, 기존 spec 의 cron 라인 불변, CLI 가 pipeline_runs 에 기록하는지).
- 생성되는 cron 라인을 직접 출력해 눈으로 확인: `40 4 * * 6 ... freeze_cleanup --apply`, 기존 8개 라인 무변경 (llm-full-daily 는 여전히 --dry-run).
- full suite: **24 failed / 803 passed** — baseline(24/799) 대비 신규 실패 0, 신규 테스트 +4. 실패 조성은 전부 기존 DB 격리 이슈 파일군이고, api 2건은 main 에서도 동일 재현됨을 확인.
- 예약 spec 이 8→9개가 되면서 개수를 하드코딩한 `test_cron_manager.py` 테스트 1건을 9로 갱신 (열거 docstring 포함).

## 참고

- **crontab 실제 설치는 하지 않았습니다** (야간 규칙 — 운영 판단). 머지 후 cron_manager 의 register 흐름으로 반영해야 실제로 돌기 시작합니다.
- **리뷰 포인트 1 (운영 결정)**: cron 을 `--apply`(실제 삭제) 로 등재했습니다. dry-run cron 은 retention 을 수행하지 않아 무의미하다고 판단했지만, LLM cron 처럼 dry-run 으로 시작하고 싶으시면 spec 의 `cron_mode` 한 줄만 지우면 됩니다.
- 의도적으로 안 한 것: `web/src/data/llm-pipeline-audit/cron.ts` (LLM 호출 파이프라인 감사 전용 인용 3건 — freeze-cleanup 은 LLM 호출이 없어 범위 밖), cleanup 개별 삭제 실패의 warnings 승격(현재 로그만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)