### PR TITLE
perf(corp-actions): 종목별 DART 호출(N+1) → 기간 일괄 조회 + corp_code 역매핑

### DIFF
--- a/kr_pipeline/corporate_actions/dart_client.py
+++ b/kr_pipeline/corporate_actions/dart_client.py
@@ -28,19 +28,23 @@ def _http_get(url: str, params: dict, timeout: int = 30) -> requests.Response:
 
 def fetch_disclosures(
     api_key: str,
-    corp_code: str,
+    corp_code: str | None,
     start_date: date,
     end_date: date,
     pblntf_ty: str = "B",
 ) -> list[dict]:
-    """corp_code 회사의 [start_date..end_date] 공시 목록 조회. 페이지네이션 자동.
+    """[start_date..end_date] 공시 목록 조회. 페이지네이션 자동.
+
+    corp_code=None 이면 파라미터 자체를 생략 — DART 가 전 회사의 공시를 반환한다
+    (기간 일괄 조회). 종목별 반복 호출(N+1) 대신 이 모드로 한 번에 받아
+    corp_code→ticker 역매핑하는 것이 정상 경로.
 
     pblntf_ty 기본값 'B'(주요사항보고): 분할·병합·합병·감자 등 기업행위 공시는
     정기공시('A': 사업/분기보고서)가 아니라 주요사항보고('B')에 실린다. 과거 'A' 기본값
     탓에 parser 가 찾을 공시가 안 들어와 corporate_actions 가 매번 0건이었음
     (2026-06-07 확인: 최근 60일 A=parser매칭 0, B=12). 따라서 'B' 가 정본.
 
-    Return: DART 응답의 list 항목들 (rcept_no, report_nm, rcept_dt 등).
+    Return: DART 응답의 list 항목들 (corp_code, rcept_no, report_nm, rcept_dt 등).
     Empty list 인 경우: 응답 status=013 (조회 결과 없음).
     Raise DartApiError if status not in ("000", "013").
     """
@@ -49,13 +53,14 @@ def fetch_disclosures(
     while True:
         params = {
             "crtfc_key": api_key,
-            "corp_code": corp_code,
             "bgn_de": start_date.strftime("%Y%m%d"),
             "end_de": end_date.strftime("%Y%m%d"),
             "pblntf_ty": pblntf_ty,
             "page_no": page_no,
             "page_count": DEFAULT_PAGE_COUNT,
         }
+        if corp_code is not None:
+            params["corp_code"] = corp_code
         response = _http_get(f"{BASE_URL}/list.json", params)
         data = response.json()
         status = data.get("status")

--- a/kr_pipeline/corporate_actions/modes.py
+++ b/kr_pipeline/corporate_actions/modes.py
@@ -49,18 +49,27 @@ def compute_date_range(
     raise ValueError(f"Unknown mode: {mode}")
 
 
-def _process_ticker(
-    conn: Connection,
-    api_key: str,
-    ticker: str,
-    corp_code: str,
-    start_date: date,
-    end_date: date,
-) -> int:
-    """한 종목의 공시 fetch → 파싱 → UPSERT. 처리 행수 반환."""
-    disclosures = fetch_disclosures(api_key, corp_code, start_date, end_date)
+def _date_chunks(start: date, end: date, *, days: int = 90):
+    """[start..end] 를 최대 `days` 일 구간으로 분할 (빈틈·중복 없음).
+
+    일괄 조회(corp_code 생략)는 전 회사 공시를 받으므로, 긴 기간(backfill 5y)을
+    한 요청으로 던지면 페이지가 폭주한다 — 구간을 나눠 요청당 페이지 수를 bound.
+    """
+    cur = start
+    while cur <= end:
+        chunk_end = min(cur + timedelta(days=days - 1), end)
+        yield cur, chunk_end
+        cur = chunk_end + timedelta(days=1)
+
+
+def _rows_from_disclosures(disclosures: list[dict], corp_to_ticker: dict[str, str]) -> list[dict]:
+    """일괄 응답 → corp_code 역매핑 + 파싱. universe 밖 회사·비대상 공시는 skip."""
     rows = []
+    seen: set[tuple] = set()
     for d in disclosures:
+        ticker = corp_to_ticker.get(d.get("corp_code"))
+        if ticker is None:
+            continue   # 우리 universe(매핑된 활성 종목) 밖 회사
         report_nm = d.get("report_nm", "")
         event_type = parse_event_type(report_nm)
         if event_type is None:
@@ -70,6 +79,10 @@ def _process_ticker(
             event_date = date(int(rcept_dt_str[:4]), int(rcept_dt_str[4:6]), int(rcept_dt_str[6:8]))
         except (ValueError, IndexError):
             continue
+        key = (ticker, event_date, event_type, d.get("rcept_no"))
+        if key in seen:
+            continue   # 같은 executemany 안 중복 → ON CONFLICT 이중 갱신 에러 방지
+        seen.add(key)
         ratio = parse_ratio(report_nm, event_type)
         rows.append({
             "ticker": ticker,
@@ -80,6 +93,19 @@ def _process_ticker(
             "dart_rcept_no": d.get("rcept_no"),
             "raw_disclosure_title": report_nm,
         })
+    return rows
+
+
+def _process_chunk(
+    conn: Connection,
+    api_key: str,
+    corp_to_ticker: dict[str, str],
+    chunk_start: date,
+    chunk_end: date,
+) -> int:
+    """한 날짜 청크의 전 회사 공시 일괄 fetch → 역매핑·파싱 → UPSERT. 처리 행수 반환."""
+    disclosures = fetch_disclosures(api_key, None, chunk_start, chunk_end)
+    rows = _rows_from_disclosures(disclosures, corp_to_ticker)
     if not rows:
         return 0
     affected = upsert_corporate_actions(conn, rows)
@@ -147,32 +173,40 @@ def run(
                     conn.commit()
 
             tickers = load_active_tickers_with_corp_code(conn, limit=limit_tickers)
-            log.info(f"tickers to process: {len(tickers)}")
+            corp_to_ticker = {corp_code: ticker for ticker, corp_code in tickers}
+            chunks = list(_date_chunks(start_date, end_date))
+            log.info(
+                f"매핑 종목 {len(tickers)}개 — 기간 일괄 조회 {len(chunks)} 청크 "
+                f"(종목별 반복 호출 아님)"
+            )
 
-            for i, (ticker, corp_code) in enumerate(tickers, 1):
+            # failures 의 첫 원소는 청크 라벨 ('YYYY-MM-DD..YYYY-MM-DD') — 일괄 조회라
+            # 실패 단위가 종목이 아니라 날짜 구간.
+            for i, (cs, ce) in enumerate(chunks, 1):
                 try:
-                    rows_total += _process_ticker(conn, api_key, ticker, corp_code, start_date, end_date)
+                    rows_total += _process_chunk(conn, api_key, corp_to_ticker, cs, ce)
                 except DartApiError as e:
-                    failures.append((ticker, str(e)))
-                    log.warning(f"{ticker}: DART API error — {e}")
+                    failures.append((f"{cs}..{ce}", str(e)))
+                    log.warning(f"chunk {cs}..{ce}: DART API error — {e}")
                     conn.rollback()
                 except Exception as e:
-                    failures.append((ticker, str(e)))
-                    log.warning(f"{ticker}: {e}")
+                    failures.append((f"{cs}..{ce}", str(e)))
+                    log.warning(f"chunk {cs}..{ce}: {e}")
                     conn.rollback()
-                if i % 100 == 0:
-                    log.info(f"progress: {i}/{len(tickers)} (failures: {len(failures)})")
+                if i % 5 == 0 or i == len(chunks):
+                    log.info(f"progress: {i}/{len(chunks)} chunks (failures: {len(failures)})")
 
-            # 끝-of-run 1회 재시도
+            # 끝-of-run 1회 재시도 (실패 청크만)
             if failures:
-                log.warning(f"Retrying {len(failures)} failed tickers")
+                log.warning(f"Retrying {len(failures)} failed chunks")
                 retry_failures = []
-                ticker_to_corp = {t: c for t, c in tickers}
-                for ticker, _ in failures:
+                for label, _ in failures:
+                    cs_str, ce_str = label.split("..")
+                    cs, ce = date.fromisoformat(cs_str), date.fromisoformat(ce_str)
                     try:
-                        rows_total += _process_ticker(conn, api_key, ticker, ticker_to_corp[ticker], start_date, end_date)
+                        rows_total += _process_chunk(conn, api_key, corp_to_ticker, cs, ce)
                     except Exception as e:
-                        retry_failures.append((ticker, str(e)))
+                        retry_failures.append((label, str(e)))
                         conn.rollback()
                 failures = retry_failures
 

--- a/tests/test_corporate_actions_dart_client.py
+++ b/tests/test_corporate_actions_dart_client.py
@@ -86,3 +86,26 @@ def test_fetch_disclosures_explicit_pblntf_ty_honored():
         fetch_disclosures("KEY", "00126380", date(2024, 1, 1), date(2024, 1, 31), pblntf_ty="C")
     args, _ = mock_get.call_args
     assert args[1]["pblntf_ty"] == "C"
+
+
+def test_fetch_disclosures_bulk_omits_corp_code():
+    """corp_code=None → 요청 파라미터에서 corp_code 자체를 생략 (전 회사 일괄 조회).
+
+    N+1 제거의 토대: 종목별 호출 대신 기간 전체 공시를 한 번에 받아 로컬에서 역매핑.
+    """
+    response = _mock_response({
+        "status": "000", "message": "정상",
+        "total_count": 1, "total_page": 1, "page_no": 1,
+        "list": [
+            {"corp_code": "00126380", "report_nm": "주식분할결정",
+             "rcept_no": "20240312000123", "rcept_dt": "20240312"},
+        ],
+    })
+    with patch(
+        "kr_pipeline.corporate_actions.dart_client._http_get", return_value=response
+    ) as mock_get:
+        result = fetch_disclosures("KEY", None, date(2024, 3, 1), date(2024, 3, 31))
+    args, _ = mock_get.call_args
+    params = args[1]
+    assert "corp_code" not in params
+    assert len(result) == 1

--- a/tests/test_corporate_actions_integration.py
+++ b/tests/test_corporate_actions_integration.py
@@ -35,18 +35,27 @@ def _seed(conn):
 
 
 def test_backfill_with_mocked_disclosures(test_db_url):
-    """공시 mock 응답 → corporate_actions 행 생성 검증."""
+    """공시 mock 응답 → corporate_actions 행 생성 검증 (일괄 조회 + 역매핑).
+
+    bulk 계약: fetch 는 corp_code=None 으로 호출되고, 응답에 섞인
+    - 매핑된 회사(11111111→CATEST1)는 적재
+    - 우리 universe 밖 회사(99999999)는 무시
+    """
     with connect(test_db_url) as conn:
         _cleanup(conn)
         _seed(conn)
 
-        # Mock 응답: CATEST1 = 액면분할 1건, CATEST2 = 공시 없음
-        def mock_fetch(api_key, corp_code, start_date, end_date, pblntf_ty="A"):
-            if corp_code == "11111111":
-                return [{
-                    "corp_code": corp_code, "report_nm": "주식분할결정",
-                    "rcept_no": "20240312000123", "rcept_dt": "20240312",
-                }]
+        calls = []
+
+        def mock_fetch(api_key, corp_code, start_date, end_date, pblntf_ty="B"):
+            calls.append(corp_code)
+            if len(calls) == 1:  # 첫 청크에만 공시 존재 (다른 청크는 빈 응답)
+                return [
+                    {"corp_code": "11111111", "report_nm": "주식분할결정",
+                     "rcept_no": "20240312000123", "rcept_dt": "20240312"},
+                    {"corp_code": "99999999", "report_nm": "주식분할결정",
+                     "rcept_no": "20240312000999", "rcept_dt": "20240312"},
+                ]
             return []
 
         try:
@@ -55,6 +64,7 @@ def test_backfill_with_mocked_disclosures(test_db_url):
 
             assert stats.rows_affected == 1
             assert stats.failures == []
+            assert calls and all(c is None for c in calls), f"bulk 호출이어야: {calls}"
 
             with conn.cursor() as cur:
                 cur.execute("SELECT ticker, event_type, dart_rcept_no FROM corporate_actions ORDER BY ticker")
@@ -70,13 +80,11 @@ def test_idempotent_incremental(test_db_url):
         _cleanup(conn)
         _seed(conn)
 
-        def mock_fetch(api_key, corp_code, start_date, end_date, pblntf_ty="A"):
-            if corp_code == "11111111":
-                return [{
-                    "corp_code": corp_code, "report_nm": "주식병합결정",
-                    "rcept_no": "20240315000456", "rcept_dt": "20240315",
-                }]
-            return []
+        def mock_fetch(api_key, corp_code, start_date, end_date, pblntf_ty="B"):
+            return [{
+                "corp_code": "11111111", "report_nm": "주식병합결정",
+                "rcept_no": "20240315000456", "rcept_dt": "20240315",
+            }]
 
         try:
             with patch("kr_pipeline.corporate_actions.modes.fetch_disclosures", side_effect=mock_fetch):
@@ -92,5 +100,31 @@ def test_idempotent_incremental(test_db_url):
 
             assert first == 1
             assert second == 1
+        finally:
+            _cleanup(conn)
+
+
+def test_incremental_fetches_once_not_per_ticker(test_db_url):
+    """7일 incremental 은 종목 수와 무관하게 fetch 1회 — N+1 제거의 핵심 계약.
+
+    (예전: 활성 매핑 종목 ~2,500개 × 회사별 DART 호출. 지금: 기간 일괄 1회.)
+    """
+    with connect(test_db_url) as conn:
+        _cleanup(conn)
+        _seed(conn)  # 매핑 종목 2개
+
+        calls = []
+
+        def mock_fetch(api_key, corp_code, start_date, end_date, pblntf_ty="B"):
+            calls.append((corp_code, start_date, end_date))
+            return []
+
+        try:
+            with patch("kr_pipeline.corporate_actions.modes.fetch_disclosures", side_effect=mock_fetch):
+                stats = run(conn, Mode.INCREMENTAL, api_key="MOCK", window_days=7)
+
+            assert stats.failures == []
+            assert len(calls) == 1, f"7일 창은 청크 1개 = 호출 1회여야: {len(calls)}회"
+            assert calls[0][0] is None
         finally:
             _cleanup(conn)

--- a/tests/test_corporate_actions_modes.py
+++ b/tests/test_corporate_actions_modes.py
@@ -32,3 +32,26 @@ def test_refresh_mapping_mode():
     # 우리 정의: refresh-mapping 일 때 (None, None) 반환
     start, end = compute_date_range(Mode.REFRESH_MAPPING)
     assert start is None and end is None
+
+
+def test_date_chunks_splits_long_range():
+    """일괄 조회의 페이지 폭주 방지 — 긴 기간을 90일 청크로 분할, 빈틈·중복 없음."""
+    from kr_pipeline.corporate_actions.modes import _date_chunks
+
+    chunks = list(_date_chunks(date(2024, 1, 1), date(2024, 12, 31), days=90))
+    assert chunks[0][0] == date(2024, 1, 1)
+    assert chunks[-1][1] == date(2024, 12, 31)
+    # 연속성: 다음 청크 시작 = 직전 청크 끝 + 1일
+    for (s1, e1), (s2, _e2) in zip(chunks, chunks[1:]):
+        assert (e1 - s1).days <= 89
+        assert s2 == e1 + timedelta(days=1)
+    # 366일(윤년) / 90 → 5청크
+    assert len(chunks) == 5
+
+
+def test_date_chunks_short_range_single_chunk():
+    """7일 창 → 청크 1개 (incremental 은 호출 1회)."""
+    from kr_pipeline.corporate_actions.modes import _date_chunks
+
+    chunks = list(_date_chunks(date(2026, 5, 10), date(2026, 5, 17), days=90))
+    assert chunks == [(date(2026, 5, 10), date(2026, 5, 17))]


### PR DESCRIPTION
## 무엇이 문제였나요? (쉬운 설명)

기업행위 공시(액면분할·합병 등)를 수집할 때, 지금까지는 **종목 하나마다 DART API 를 한 번씩** 불렀습니다. 활성 종목이 약 2,500개이니 평일 아침 cron 한 번에 수천 번의 HTTP 요청이 나가는 구조였습니다. 사실 DART API 는 회사를 지정하지 않으면 "이 기간의 모든 회사 공시"를 한 번에 돌려줄 수 있는데, 그 기능을 안 쓰고 있었습니다.

## 왜 위험한가요?

DART 는 하루 20,000회 호출 제한이 있습니다. 매일 수천 회를 여기에 쓰면 다른 용도(기업코드 매핑 갱신, 백필)의 여유가 줄고, 요청이 많을수록 간헐 실패·재시도로 실행 시간도 길어집니다. 5년 백필은 이 구조로는 수천~수만 회 호출이 됩니다.

## 무엇을 고쳤나요?

- `kr_pipeline/corporate_actions/dart_client.py` — `fetch_disclosures` 가 `corp_code=None` 을 받으면 해당 파라미터를 아예 생략해 **전 회사 일괄 조회**로 동작합니다. 회사를 지정하는 기존 사용법은 그대로입니다.
- `kr_pipeline/corporate_actions/modes.py` — 종목 루프를 없애고: ① 기간을 90일 청크로 나눠(백필의 페이지 폭주 방지) ② 청크마다 일괄 조회 1회 ③ 응답의 corp_code 를 우리 종목으로 **로컬 역매핑** (universe 밖 회사는 무시, 같은 배치 내 중복 키는 dedup). 실패/재시도 단위는 종목 → 날짜 청크로 바뀌었고, 청크별 commit 으로 부분 진행이 보존됩니다.

효과: **증분(7일) = 종목 수와 무관하게 API 호출 1회**(+페이지네이션). 5년 백필 = 21청크. 예전에는 각각 ~2,500회 이상이었습니다.

## 어떻게 검증했나요?

- TDD: 테스트 6건 red 확인 → 구현 → green. 핵심 계약을 각각 고정: corp_code 생략 여부, "7일 증분은 호출 1회", 90일 청크 분할(빈틈·중복 없음), 역매핑 적재 + universe 밖 공시 무시, 멱등(두 번 돌려도 행 수 동일).
- corporate_actions 계열 전체 44 passed. DART 실호출 없음 — 전부 mock.
- full suite 20 failed / 807 passed — 실패는 전부 main 의 기존 테스트 격리 이슈 파일군(**PR #12 가 수정**, 이 브랜치엔 미포함)이고 corporate_actions 쪽 신규 실패는 0입니다.

## 참고

- 멱등성 근거: 적재가 `(ticker, event_date, event_type, dart_rcept_no)` ON CONFLICT upsert 라 같은 공시를 다시 받아도 중복이 생기지 않습니다 (기존 계약 그대로).
- 동작 의미 변화 1: `limit_tickers` 는 이제 "이 종목들만 fetch" 가 아니라 "역매핑 대상을 이 종목들로 제한" 입니다 (일괄 응답에서 그 외는 버림). 결과 행은 동일합니다.
- 동작 의미 변화 2: `RunStats.failures` 의 첫 원소가 종목 티커 → 날짜 청크 라벨(`2026-04-09..2026-07-08`)로 바뀝니다. 이 필드를 파싱하는 소비처는 없음을 확인했습니다 (로그·run_tracking 표시용).
- 의도적으로 안 한 것: production 백필 재실행 (운영 판단 — 코드만 머지해도 다음 cron 부터 새 경로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)