### PR TITLE
docs: LLM 리뷰 시리즈 4편 — 결정론 분리·효율화·모순·비효율 감사 리포트

### DIFF
--- a/docs/artifacts/2026-07-08-llm-review-series/01-deterministic-extraction.html
+++ b/docs/artifacts/2026-07-08-llm-review-series/01-deterministic-extraction.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LLM에서 결정론적으로 뺄 수 있는 것들 — kr-by-claude 리뷰 시리즈 1/4</title>
+<style>
+  :root {
+    --paper: #f7f3ea;
+    --paper-deep: #efe8d8;
+    --ink: #2b2620;
+    --ink-soft: #5c544a;
+    --accent: #8a3324;        /* 옥스블러드 */
+    --accent-soft: #f3e0da;
+    --teal: #1f5f5b;          /* 결정론=코드 색 */
+    --teal-soft: #dcebe9;
+    --gold: #a07d2a;          /* LLM=판단 색 */
+    --gold-soft: #f2ead2;
+    --line: #d8cfbd;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--paper);
+    background-image: radial-gradient(circle at 15% 8%, rgba(160,125,42,.06), transparent 40%),
+                      radial-gradient(circle at 90% 95%, rgba(31,95,91,.05), transparent 45%);
+    color: var(--ink);
+    font-family: "Apple SD Gothic Neo", "Noto Sans KR", "Pretendard", sans-serif;
+    line-height: 1.75;
+    font-size: 16.5px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 0 28px 120px; }
+
+  header.masthead {
+    padding: 72px 0 40px;
+    border-bottom: 3px double var(--ink);
+    margin-bottom: 8px;
+  }
+  .series-tag {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .18em;
+    text-transform: uppercase; color: var(--accent);
+    display: inline-block; border: 1px solid var(--accent);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 24px;
+  }
+  h1 {
+    font-family: "Nanum Myeongjo", "Apple SD Gothic Neo", serif;
+    font-size: clamp(30px, 5vw, 44px);
+    font-weight: 800; line-height: 1.3; letter-spacing: -0.01em;
+    margin-bottom: 18px;
+  }
+  h1 em { font-style: normal; color: var(--accent); }
+  .dek { font-size: 18px; color: var(--ink-soft); max-width: 42em; }
+  .byline { margin-top: 22px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); }
+
+  nav.toc {
+    margin: 36px 0 56px; padding: 22px 26px;
+    background: var(--paper-deep); border-left: 4px solid var(--ink);
+  }
+  nav.toc strong { display:block; font-size: 13px; letter-spacing:.12em; margin-bottom: 10px; }
+  nav.toc ol { margin-left: 20px; }
+  nav.toc a { color: var(--ink); text-decoration: none; border-bottom: 1px dotted var(--ink-soft); }
+  nav.toc a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+  section { margin-bottom: 72px; }
+  h2 {
+    font-family: "Nanum Myeongjo", serif;
+    font-size: 27px; font-weight: 800; margin-bottom: 6px;
+    display: flex; align-items: baseline; gap: 14px;
+  }
+  h2 .no {
+    font-family: var(--mono); font-size: 15px; color: var(--accent);
+    border: 1.5px solid var(--accent); border-radius: 50%;
+    width: 32px; height: 32px; flex: 0 0 32px;
+    display: inline-flex; align-items: center; justify-content: center;
+    transform: translateY(-2px);
+  }
+  h3 { font-size: 19px; margin: 34px 0 10px; }
+  .rule { width: 64px; height: 3px; background: var(--accent); margin: 14px 0 22px; }
+  p { margin-bottom: 16px; max-width: 46em; }
+  ul, ol { margin: 0 0 18px 24px; }
+  li { margin-bottom: 8px; max-width: 44em; }
+  strong { font-weight: 700; }
+  code {
+    font-family: var(--mono); font-size: .85em;
+    background: var(--paper-deep); padding: 2px 6px; border-radius: 4px;
+    border: 1px solid var(--line);
+  }
+
+  .callout {
+    margin: 26px 0; padding: 20px 24px; border-radius: 6px;
+    background: var(--accent-soft); border-left: 4px solid var(--accent);
+  }
+  .callout.teal { background: var(--teal-soft); border-left-color: var(--teal); }
+  .callout.gold { background: var(--gold-soft); border-left-color: var(--gold); }
+  .callout .label {
+    font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em;
+    text-transform: uppercase; display: block; margin-bottom: 8px;
+  }
+  .callout p:last-child { margin-bottom: 0; }
+
+  .badge {
+    display: inline-block; font-family: var(--mono); font-size: 11px;
+    letter-spacing: .06em; padding: 2px 9px; border-radius: 999px;
+    vertical-align: 1px; white-space: nowrap;
+  }
+  .badge.code { background: var(--teal); color: #fff; }
+  .badge.llm  { background: var(--gold); color: #fff; }
+  .badge.mix  { background: linear-gradient(100deg, var(--teal) 48%, var(--gold) 52%); color:#fff; }
+
+  .tbl-scroll { overflow-x: auto; margin: 22px 0; border: 1px solid var(--line); border-radius: 8px; background: #fffdf7; }
+  table { border-collapse: collapse; width: 100%; font-size: 14.5px; min-width: 640px; }
+  th {
+    text-align: left; font-size: 12px; letter-spacing: .08em;
+    padding: 12px 16px; background: var(--paper-deep);
+    border-bottom: 2px solid var(--ink); white-space: nowrap;
+  }
+  td { padding: 12px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+
+  .site-card {
+    border: 1.5px solid var(--ink); border-radius: 10px;
+    background: #fffdf7; margin: 30px 0; overflow: hidden;
+    box-shadow: 5px 5px 0 rgba(43,38,32,.10);
+  }
+  .site-card .head {
+    padding: 18px 24px; background: var(--ink); color: var(--paper);
+    display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px;
+  }
+  .site-card .head h3 { margin: 0; font-size: 18px; color: var(--paper); }
+  .site-card .head .file { font-family: var(--mono); font-size: 11.5px; opacity: .75; }
+  .site-card .body { padding: 22px 24px; }
+
+  .flow {
+    display: flex; flex-wrap: wrap; gap: 10px; align-items: stretch;
+    margin: 20px 0; font-size: 13.5px;
+  }
+  .flow .step {
+    flex: 1 1 150px; padding: 12px 14px; border-radius: 8px;
+    border: 1.5px solid var(--line); background: #fffdf7; position: relative;
+  }
+  .flow .step.det { border-color: var(--teal); background: var(--teal-soft); }
+  .flow .step.llm { border-color: var(--gold); background: var(--gold-soft); }
+  .flow .step .t { font-weight: 700; display: block; margin-bottom: 4px; font-size: 13px; }
+  .flow .step .d { color: var(--ink-soft); font-size: 12.5px; line-height: 1.55; display:block; }
+  .flow .arrow { align-self: center; color: var(--ink-soft); font-size: 18px; }
+
+  .verdict {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 22px 0;
+  }
+  @media (max-width: 640px) { .verdict { grid-template-columns: 1fr; } }
+  .verdict > div { padding: 18px 20px; border-radius: 8px; font-size: 14.5px; }
+  .verdict .yes { background: var(--teal-soft); border: 1.5px solid var(--teal); }
+  .verdict .no  { background: var(--gold-soft); border: 1.5px solid var(--gold); }
+  .verdict .hd { font-weight: 800; margin-bottom: 10px; font-size: 15px; }
+  .verdict ul { margin-left: 18px; margin-bottom: 0; }
+  .verdict li { font-size: 13.5px; margin-bottom: 6px; }
+
+  .rank { counter-reset: rk; margin: 26px 0; }
+  .rank .item {
+    display: flex; gap: 18px; padding: 20px 0; border-bottom: 1px solid var(--line);
+  }
+  .rank .item::before {
+    counter-increment: rk; content: counter(rk);
+    font-family: "Nanum Myeongjo", serif; font-size: 34px; font-weight: 800;
+    color: var(--accent); line-height: 1; flex: 0 0 36px;
+  }
+  .rank .item h4 { font-size: 16.5px; margin-bottom: 6px; }
+  .rank .item p { font-size: 14.5px; color: var(--ink-soft); margin-bottom: 0; }
+
+  footer {
+    margin-top: 90px; padding-top: 24px; border-top: 3px double var(--ink);
+    font-family: var(--mono); font-size: 12px; color: var(--ink-soft);
+    display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px;
+  }
+  .fade { animation: fadeUp .7s ease both; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(14px);} to { opacity: 1; transform: none;} }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead fade">
+  <span class="series-tag">kr-by-claude 리뷰 시리즈 · 1 / 4</span>
+  <h1>LLM이 하는 일 중,<br><em>계산기로 옮길 수 있는 것들</em></h1>
+  <p class="dek">이 프로젝트는 세 곳에서 Claude(LLM)를 호출한다. 그런데 LLM에게 시키는 일의 상당 부분은 사실 "정해진 규칙대로 숫자를 비교하는 일"이다. 이런 일은 일반 코드로 빼면 더 싸고, 더 빠르고, 결과가 절대 흔들리지 않는다. 이 문서는 어디를 뺄 수 있고, 어디는 반드시 LLM이어야 하는지를 초보자 눈높이로 정리한다.</p>
+  <p class="byline">작성 2026-07-08 밤 · 코드 기준 origin/main · 자동 생성 후 리뷰 반복 검증</p>
+</header>
+
+<nav class="toc fade">
+  <strong>차례</strong>
+  <ol>
+    <li><a href="#basics">먼저: "결정론적"이 무슨 뜻인가</a></li>
+    <li><a href="#map">이 프로젝트가 LLM을 쓰는 세 곳</a></li>
+    <li><a href="#site-a">사이트 A — 차트 분류 (analyze_chart)</a></li>
+    <li><a href="#site-b">사이트 B — 매수 타이밍 확인 (evaluate_pivot)</a></li>
+    <li><a href="#site-c">사이트 C — 매수 파라미터 계산 (entry_params)</a></li>
+    <li><a href="#priority">무엇부터 빼면 좋은가 — 우선순위</a></li>
+    <li><a href="#caution">뺄 때 반드시 지켜야 할 것</a></li>
+  </ol>
+</nav>
+
+<section id="basics" class="fade">
+  <h2><span class="no">1</span>먼저: "결정론적"이 무슨 뜻인가</h2>
+  <div class="rule"></div>
+  <p><strong>결정론적(deterministic)</strong>이란 "같은 입력을 넣으면 언제나 정확히 같은 출력이 나온다"는 뜻이다. 계산기가 대표적이다. <code>3 &gt; 2</code>는 백 번 물어도 참이다.</p>
+  <p>반면 <strong>LLM은 확률적</strong>이다. 같은 차트를 두 번 보여주면 대체로 비슷하게 답하지만, 가끔 다르게 답한다. 이 프로젝트의 메모에도 "LLM 비결정성 때문에 재실행 비교 금지"라는 규칙이 있을 정도다.</p>
+  <div class="callout">
+    <span class="label">핵심 구분법</span>
+    <p>LLM에게 시키는 일을 한 문장으로 적어보고 이렇게 물어보면 된다 — <strong>"이 일은 숫자와 규칙만으로 답이 정해지는가?"</strong></p>
+    <p>"거래량이 50일 평균의 1.4배를 넘는가?" → 숫자 비교다. 코드로 빼야 한다. <span class="badge code">코드</span><br>
+    "이 차트의 바닥이 완만한 U자인가, 급한 V자인가?" → 모양을 보는 눈이 필요하다. LLM이 맡는다. <span class="badge llm">LLM</span></p>
+  </div>
+  <p>이 문서에서 자주 나오는 용어 네 개만 먼저 짚는다.</p>
+  <ul>
+    <li><strong>pivot(피벗)</strong> — "이 가격을 넘어서면 매수를 고려한다"는 <em>돌파 기준 가격선</em>. 보통 차트 바닥권(베이스)의 고점 근처에 놓인다.</li>
+    <li><strong>payload(페이로드)</strong> — LLM에게 건네주는 <em>입력 데이터 묶음</em>(가격·거래량·지표 등을 담은 JSON).</li>
+    <li><strong>분배일(distribution day)</strong> — 거래량이 실린 하락일. "기관이 물량을 던진 흔적"으로 읽는 신호다.</li>
+    <li><strong>§ 표기</strong> — 아래에서 "§3.1"처럼 쓰는 절 번호는 <em>이 문서가 아니라 각 프롬프트 파일(.md)의 절 번호</em>다. 프롬프트를 열면 해당 규칙을 그대로 찾을 수 있다.</li>
+  </ul>
+  <p>왜 빼는 게 좋은가? 세 가지다.</p>
+  <ul>
+    <li><strong>비용</strong> — LLM 호출은 토큰(= 돈과 시간)을 쓴다. 숫자 비교를 LLM에게 시키는 것은 회계사에게 "1+1을 계산해 달라"고 의뢰하는 것과 같다.</li>
+    <li><strong>정확성</strong> — LLM은 산수를 가끔 틀린다. 실제로 이 프로젝트에는 LLM이 payload의 현재가를 잘못 읽는 사고를 잡으려고 "echo 검증"(LLM이 받은 숫자를 그대로 되뇌게 해서 대조)까지 만들어져 있다. 코드는 애초에 틀리지 않는다.</li>
+    <li><strong>재현성</strong> — 백테스트나 감사를 할 때 결정론 부분은 언제든 똑같이 재실행해 검증할 수 있다. LLM 부분은 그게 안 된다. 결정론 영역이 넓어질수록 검증 가능한 영역이 넓어진다.</li>
+  </ul>
+</section>
+
+<section id="map" class="fade">
+  <h2><span class="no">2</span>이 프로젝트가 LLM을 쓰는 세 곳</h2>
+  <div class="rule"></div>
+  <p>모든 LLM 호출은 <code>kr_pipeline/llm_runner/llm/claude_cli.py</code>의 <code>call_claude()</code> 하나를 거친다. 이 관문을 통해 실제로 쓰이는 프롬프트는 3개다. (4번째 프롬프트 <code>verify_analysis_v1.md</code>도 있지만, 이것은 파이프라인이 호출하지 않고 사람이 수동 검증할 때 쓰라고 ZIP에 동봉되는 문서다.)</p>
+  <div class="flow">
+    <div class="step det"><span class="t">결정론 스크리너</span><span class="d">Minervini 8조건 통과 종목만 추림 (LLM 없음)</span></div>
+    <span class="arrow">→</span>
+    <div class="step llm"><span class="t">A. 차트 분류</span><span class="d">entry / watch / ignore 판정 + 패턴 인식</span></div>
+    <span class="arrow">→</span>
+    <div class="step llm"><span class="t">B. 매수 타이밍</span><span class="d">"오늘 사도 되나?" go_now / wait / abort</span></div>
+    <span class="arrow">→</span>
+    <div class="step llm"><span class="t">C. 매수 파라미터</span><span class="d">진입가·손절가·비중·목표가 산출</span></div>
+  </div>
+  <div class="tbl-scroll"><table>
+    <thead><tr><th>사이트</th><th>프롬프트</th><th>입력에 차트 이미지?</th><th>출력</th><th>결정론화 여지</th></tr></thead>
+    <tbody>
+      <tr><td><strong>A</strong> 차트 분류</td><td><code>analyze_chart_v3.md</code> (577줄)</td><td><strong>있음</strong> (일봉+주봉 PNG 2장)</td><td>분류·패턴·pivot·리스크 플래그·근거문</td><td>부분 <span class="badge mix">혼합</span></td></tr>
+      <tr><td><strong>B</strong> 매수 타이밍</td><td><code>evaluate_pivot_trigger_v1.md</code> (171줄)</td><td>없음 (숫자 JSON만)</td><td>go_now / wait / abort + 근거</td><td>대부분 <span class="badge code">코드</span></td></tr>
+      <tr><td><strong>C</strong> 매수 파라미터</td><td><code>calculate_entry_params_v2_0.md</code> (595줄)</td><td>없음 (숫자 JSON만)</td><td>17개 필드 (진입가·손절·비중…)</td><td>거의 전부 <span class="badge code">코드</span></td></tr>
+    </tbody>
+  </table></div>
+  <div class="callout teal">
+    <span class="label">한눈에 보는 결론</span>
+    <p>차트 <strong>이미지를 보는 일은 A뿐</strong>이다. B와 C는 LLM에게 숫자 JSON만 주고 "규칙대로 판정/계산하라"고 시킨다. 즉 B와 C는 구조적으로 결정론화에 훨씬 가깝고, 특히 C는 프롬프트 자체가 사실상 계산 절차서다.</p>
+  </div>
+</section>
+
+<section id="site-a" class="fade">
+  <h2><span class="no">3</span>사이트 A — 차트 분류 (analyze_chart)</h2>
+  <div class="rule"></div>
+
+  <div class="site-card">
+    <div class="head">
+      <h3>A. analyze_chart_v3 — "이 종목, 살 후보인가?"</h3>
+      <span class="file">weekend.py · daily_delta.py · backfill.py → prompts/analyze_chart_v3.md</span>
+    </div>
+    <div class="body">
+      <p><strong>지금 하는 일:</strong> 결정론 스크리너를 통과한 종목마다 차트 PNG 2장(일봉·주봉)과 숫자 데이터(OHLCV, 지표, 시장 맥락)를 주고 <code>entry</code>(진입 후보) / <code>watch</code>(관찰) / <code>ignore</code>(제외)로 분류하게 한다. 패턴 이름(컵앤핸들, VCP 등), pivot 가격, 리스크 플래그, 한국어 근거문도 함께 받는다.</p>
+      <p><strong>이미 결정론으로 둘러싸여 있다:</strong> 앞단에서 결정론 스크리너가 후보를 거르고, 뒷단에서 <code>handle_quality</code>(핸들 품질을 DB 숫자로 재계산), monotone backstop(LLM 판정을 절대 승격시키지 않는 안전장치), 가격 sanity 검증이 LLM 출력을 다시 검사한다. 즉 "LLM을 못 믿겠으면 코드로 재검산한다"는 패턴이 이미 이 프로젝트의 관례다.</p>
+
+      <div class="verdict">
+        <div class="yes">
+          <div class="hd">코드로 뺄 수 있는 것 <span class="badge code">코드</span></div>
+          <ul>
+            <li><strong>§2 마진 카운트</strong> — "8개 조건 중 3개 이상이 3% 미만 여유면 confidence를 낮춰라". 조건별 마진은 payload의 <code>conditions_detail</code>에 이미 숫자로 들어 있다. 세는 건 코드 몫이다.</li>
+            <li><strong>§3.5 시장 방향 하드룰</strong> — "시장이 하락세면 최대 watch". 시장 상태는 결정론 계산된 <code>market_context</code>로 전달된다. if문이면 끝난다.</li>
+            <li><strong>§4.7 pivot 산술</strong> — "pivot = 핸들 고가 + 0.1" 같은 덧셈. 어느 고가를 쓸지(패턴 판정)는 LLM이 정하더라도, 덧셈은 코드가 하면 된다.</li>
+            <li><strong>§8.5 watch_reason ±5% 밴드</strong> — pivot이 확정된 종목의 현재가가 pivot의 ±5% 안인지 계산해 "돌파 대기(watch) / 진입(entry) / 이미 연장(watch)" 세 구간을 가르는 산술 부분. 단, 그 전제인 "pivot이 정의될 만큼 베이스가 완성됐는가"는 구조 판단이라 LLM에 남는다.</li>
+            <li><strong>§6.1/§6.2 climax·topping 정량 게이트</strong> — "3주에 25% 이상 급등", "10주선 아래 8주" 같은 조건은 주봉 숫자 비교다. <code>handle_quality</code>를 결정론으로 뺀 것과 똑같은 방식으로 뺄 수 있다. 단서: §6.1의 기준점(상승 국면 시작점) 식별과 소진 갭(exhaustion gap) 판정은 판단 요소라, 그 부분만 근사 정의가 필요하다.</li>
+          </ul>
+          <p style="font-size:13px; color:var(--ink-soft); margin:10px 0 0;">참고 — 프롬프트 첫머리의 "ETF면 무조건 ignore" 규칙은 결정론화 대상이 <em>아니다</em>. ETF·리츠·스팩 등은 이미 유니버스 적재 단계(<code>universe/transform.py</code>)에서 결정론적으로 걸러지므로 ETF가 LLM 앞까지 오는 일 자체가 없다. 프롬프트의 이 규칙은 만약을 위한 방어층이다.</p>
+        </div>
+        <div class="no">
+          <div class="hd">LLM에 남겨야 하는 것 <span class="badge llm">LLM</span></div>
+          <ul>
+            <li><strong>바닥 모양 인식</strong> — 완만한 U자인지 급한 V자인지, 둥근바닥인지. 숫자 몇 개로 환원하기 어려운 시각 판단.</li>
+            <li><strong>VCP 수축의 "조여듦"</strong> — 수축 횟수는 셀 수 있어도, 전체적으로 깔끔하게 조여드는 질감인지는 판단의 영역.</li>
+            <li><strong>핸들 drift 방향, shakeout, wedging</strong> — 미묘한 형태 신호.</li>
+            <li><strong>wide-and-loose 질감</strong> — "차트가 지저분하다"는 종합 인상.</li>
+            <li><strong>한국어 근거문 작성</strong> — 사람이 읽을 설명문 생성은 LLM 고유 영역.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="callout gold">
+        <span class="label">현실적인 형태</span>
+        <p>A는 "LLM 제거"가 아니라 <strong>역할 축소</strong>가 정답이다: 정량 게이트는 코드가 먼저 계산해 결과를 payload에 넣어주고, LLM은 "모양 인식 + 그 결과의 종합"만 맡는 구조. 이미 <code>handle_quality</code>·<code>failed_breakout</code>이 이 방식으로 옮겨진 선례가 있어서, 같은 길을 따라가면 된다.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="site-b" class="fade">
+  <h2><span class="no">4</span>사이트 B — 매수 타이밍 확인 (evaluate_pivot)</h2>
+  <div class="rule"></div>
+
+  <div class="site-card">
+    <div class="head">
+      <h3>B. evaluate_pivot_trigger_v1 — "오늘 사도 되는 날인가?"</h3>
+      <span class="file">evaluate_pivot.py → prompts/evaluate_pivot_trigger_v1.md</span>
+    </div>
+    <div class="body">
+      <p><strong>지금 하는 일:</strong> A에서 entry/watch로 분류된 종목이 pivot 가격을 돌파하는 등 조건이 무르익으면, 차트 없이 숫자 JSON만 주고 <code>go_now</code>(지금 매수) / <code>wait</code>(대기) / <code>abort</code>(포기) 중 하나를 판정하게 한다.</p>
+      <p><strong>재미있는 설계:</strong> 이미 <code>trigger_gate.py</code>라는 결정론 게이트가 "거래량 1.0배 이상" 같은 <em>느슨한</em> 1차 필터를 하고, "정밀 판정(1.4배 기준 등)은 LLM에게"라고 일부러 위임해 놓았다. 그런데 그 정밀 판정의 대부분도 사실 숫자 비교다.</p>
+
+      <div class="verdict">
+        <div class="yes">
+          <div class="hd">코드로 뺄 수 있는 것 <span class="badge code">코드</span></div>
+          <ul>
+            <li><strong>go_now 5대 정량 조건(§3.1)</strong> — ① 종가 &gt; pivot, ② 거래량 &gt; 50일 평균 × 1.4, ③ 종가가 당일 범위의 상단 ⅓ (<code>(close−low)/(high−low) ≥ ⅔</code>), ④ 당일 변동폭 ≤ 평균 × 1.5, ⑤ 최근 3일 분배일 없음. 모두 산술이다. 다만 ①~③은 payload 숫자로 바로 되고, ④는 "평균 변동폭"의 기간 정의를 새로 정해야 하며, ⑤는 일자별 50일 평균 거래량이 payload에 없어 payload 확장(또는 DB 조회)이 필요하다 — "그대로 옮기면 끝"은 아니고 운영 정의 몇 개를 박는 작업이 따른다.</li>
+            <li><strong>이동평균선 가드</strong> — sma_21, sma_50 대비 위치 비교. payload에 이미 계산돼 들어 있다.</li>
+            <li><strong>invalidation·promotion의 정량 조건(§3.2, §3.3)</strong> — 가격이 기준선 아래로 얼마나, 며칠간, 같은 셈이다.</li>
+            <li><strong>§3.5 breakout_from_watch의 watch_reason별 게이트</strong> — 예: watch 사유가 "시장 여건 불리"였으면 <code>market_context</code>가 confirmed_uptrend일 때만 go_now, "마진 부족"이었으면 8조건 전부 통과 + 마진 3% 이상 회복일 때만 go_now. §3.1보다도 더 순수한 if문 규칙인데 지금 LLM이 수행 중이다.</li>
+          </ul>
+        </div>
+        <div class="no">
+          <div class="hd">LLM에 남겨야 하는 것 <span class="badge llm">LLM</span></div>
+          <ul>
+            <li><strong>경계 상황의 종합 판단</strong> — "오늘 음봉이 일회성 흔들기(shakeout)인지, 베이스 붕괴의 시작인지"는 규칙 몇 줄로 안 끝난다.</li>
+            <li><strong>abort 사유의 서술</strong> — 8종 카탈로그 중 고르는 것 자체는 규칙화 가능하지만, 애매한 경계의 해석은 판단이다.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="callout teal">
+        <span class="label">가장 실속 있는 중간 단계</span>
+        <p>정량 조건 5개를 코드로 미리 계산해서 <strong>"조건 체크 결과표"를 payload에 넣어주는 것</strong>만으로도 효과가 크다. LLM은 산수를 다시 할 필요 없이 "체크는 다 통과했는데 미심쩍은 정황이 있는가?"만 보면 된다. 정량 조건이 하나라도 명확히 미달이면 LLM을 부르지 않고 코드가 바로 wait 처리할 수도 있다 — 호출 수 자체가 줄어든다.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="site-c" class="fade">
+  <h2><span class="no">5</span>사이트 C — 매수 파라미터 계산 (entry_params)</h2>
+  <div class="rule"></div>
+
+  <div class="site-card">
+    <div class="head">
+      <h3>C. calculate_entry_params_v2_0 — "얼마에 사고, 어디서 손절하고, 얼마나 살까?"</h3>
+      <span class="file">entry_params.py → prompts/calculate_entry_params_v2_0.md</span>
+    </div>
+    <div class="body">
+      <p><strong>지금 하는 일:</strong> B에서 go_now가 나온 종목에 대해, 숫자 JSON을 주고 진입 트리거가·손절가·포지션 비중·목표수익·유효기간 등 17개 필드를 산출하게 한다.</p>
+      <p><strong>솔직한 진단:</strong> 이 프롬프트(595줄)는 읽어보면 <em>계산 절차서</em>다. 몇 가지만 보자.</p>
+      <ul>
+        <li>트리거가 = <code>round(pivot × 1.001, 2)</code> — 그냥 곱셈이다.</li>
+        <li>손절 = "고정 −7%(특정 플래그면 −5.5%)와 논리적 손절((base_low×0.995−pivot)/pivot) 중 덜 깊은 쪽, 그리고 −10%~−5% 사이로 자르기" — max와 clamp다.</li>
+        <li>비중 = 패턴별 기본값(15/10/7/5%) × 리스크 플래그 배수(×0.7, ×0.5) 후 3~25%로 자르기 — 곱셈표다.</li>
+        <li>목표수익 = 기본 20%, VCP면 25%, 특정 조건이면 15%, 15~50%로 자르기 — 조회표다.</li>
+      </ul>
+      <p>게다가 프롬프트 끝에는 §11 "계산 체크리스트"가 있는데, 이것은 사실상 <strong>이 계산의 의사코드(pseudocode)</strong>다. 출력이 오면 코드가 echo 검증(현재가 오독 탐지)과 HARD/SOFT sanity 검증을 돌리는데 — 주의할 점은 이 검증이 <strong>범위·정합성 검사일 뿐 산식 재계산이 아니라는 것</strong>이다. "손절가가 진입가보다 높으면 거부" 같은 구조적 불가능과 책 권장 범위 이탈만 잡지, 티어 선택이나 배수 적용이 맞았는지는 아무도 재검산하지 않는다. 즉 지금 구조에서는 LLM이 곱셈표를 잘못 적용해도 범위 안이기만 하면 그대로 저장된다. 결정론 함수로 바꾸면 이 빈틈 자체가 사라진다.</p>
+
+      <div class="verdict">
+        <div class="yes">
+          <div class="hd">코드로 뺄 수 있는 것 <span class="badge code">코드</span></div>
+          <ul>
+            <li><strong>17필드 거의 전부.</strong> 입력(pivot, base_low, close, sma50, 플래그들)이 모두 숫자이고 규칙이 모두 명시돼 있으므로, 프롬프트 §11 체크리스트를 그대로 Python 함수로 옮기면 된다.</li>
+            <li>부수 효과: LLM 호출 1회 제거, echo 검증·sanity 검증 같은 방어 장치도 상당 부분 불필요해짐(코드는 오독하지 않으므로), 백테스트에서 완전 재현 가능.</li>
+          </ul>
+        </div>
+        <div class="no">
+          <div class="hd">LLM에 남겨야 하는 것 <span class="badge llm">LLM</span></div>
+          <ul>
+            <li><strong>많지 않지만, 0은 아니다.</strong> ① <em>3c_cheat 판정</em> — A는 컵앤핸들까지만 식별하고, "컵 하단~중단 ⅓에 쉼표(pause) 구간이 있는가"를 보고 cheat 진입으로 세분하는 일은 프롬프트가 명시적으로 C의 몫으로 규정한다. ② <em>pattern이 none일 때의 폴백</em> — "최근 5주 횡보 구간 고가에 pivot을 놓아라"는 규칙은 "횡보 구간"의 식별이 필요하다. ③ <em>VCP 마지막 수축폭 기준의 추격 한도</em> — 필요한 수축폭 데이터가 현재 payload에 전달되지 않는다.</li>
+            <li>따라서 "통째 대체"를 하려면 이 세 분기를 <strong>결정론 근사로 재정의하거나 보수적 기본값으로 포기</strong>하는 결정이 선행돼야 한다. 세 경우 모두 발생 빈도가 낮고 보수적 폴백이 자연스러워, 대체 자체를 막을 정도는 아니다.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="callout">
+        <span class="label">가장 확실한 1순위</span>
+        <p>C는 "LLM 축소"가 아니라 <strong>통째로 결정론 함수로 대체</strong>가 가능한 사이트다. 위험도 가장 낮다 — 이미 존재하는 검증 코드(echo·sanity)가 정답 범위를 정의하고 있고, 과거 LLM 출력 로그와 새 함수 출력을 나란히 비교(백필 패턴 판정)하면 이행 검증도 결정론적으로 끝난다.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="priority" class="fade">
+  <h2><span class="no">6</span>무엇부터 빼면 좋은가 — 우선순위</h2>
+  <div class="rule"></div>
+  <div class="rank">
+    <div class="item">
+      <div>
+        <h4>사이트 C 전체를 결정론 함수로 대체 <span class="badge code">효과 大 · 위험 小</span></h4>
+        <p>프롬프트가 이미 알고리즘이고, 검증 코드가 정답 범위를 알고 있다. LLM 호출 하나가 통째로 사라지고, 산수 오적용 리스크가 0이 된다. 선행 결정 3건(3c_cheat·none 폴백·VCP 추격한도의 결정론 근사)을 먼저 확정할 것. 이행 검증: 과거 go_now 건들에 대해 새 함수를 돌려 저장된 LLM 출력과 필드별 비교.</p>
+      </div>
+    </div>
+    <div class="item">
+      <div>
+        <h4>사이트 B의 정량 게이트 전부를 코드 선계산으로 <span class="badge mix">효과 中 · 위험 小</span></h4>
+        <p>거래량 1.4배, 상단 ⅓ 마감, 변동폭, 분배일 카운트, 이평선 가드, watch_reason별 게이트(§3.5)를 코드가 먼저 계산해 결과표로 전달. 명백 미달 건은 LLM 호출 없이 wait 처리 → 호출 수 감소. LLM은 경계 상황의 종합 판단만 담당.</p>
+      </div>
+    </div>
+    <div class="item">
+      <div>
+        <h4>사이트 A의 정량 게이트를 순차적으로 이관 <span class="badge mix">효과 中 · 위험 中</span></h4>
+        <p>§2 마진 카운트 → §3.5 시장 하드룰 → §8.5 watch_reason 밴드(산술 부분) → §6.1/6.2 climax·topping 게이트 순. <code>handle_quality</code> 이관 때 쓴 "코드로 재계산 + monotone backstop" 패턴을 재사용.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="caution" class="fade">
+  <h2><span class="no">7</span>뺄 때 반드시 지켜야 할 것</h2>
+  <div class="rule"></div>
+  <ul>
+    <li><strong>임계값의 단일 출처(SSOT)를 지켜라.</strong> 책에서 온 임계값은 <code>kr_pipeline/common/thresholds.py</code>가 유일한 정의다. 결정론화하면서 숫자를 코드에 하드코딩하지 말고 반드시 thresholds.py를 import 해야 한다. 프롬프트 문구와 thresholds.py의 정합은 <code>test_prompt_threshold_drift.py</code>가 감시하고 있는데, 규칙을 프롬프트에서 <em>빼면</em> 이 테스트와 프로젝트의 임계 변경 체크리스트(의존성 맵)도 함께 갱신해야 한다.</li>
+    <li><strong>LLM 축소는 곧 프롬프트 변경이다.</strong> 프롬프트에서 규칙을 덜어낼 때, 남은 규칙들이 그 규칙을 참조하고 있지 않은지(예: confidence 감점 규칙이 마진 카운트를 전제) 의존성을 점검해야 한다.</li>
+    <li><strong>비교 검증은 "패턴 판정"으로.</strong> LLM은 비결정적이므로 "결정론 함수 결과 = LLM 재실행 결과" 식의 1:1 비교는 성립하지 않는다. 과거 <em>저장된</em> LLM 출력 로그와 비교하고, 차이는 건별로 어느 쪽이 규칙에 충실한지 판정하는 방식이어야 한다.</li>
+    <li><strong>단계적으로, 한 번에 하나씩.</strong> C 전체 → B 정량 → A 부분 순으로, 각 단계마다 백테스트 재현으로 확인하고 넘어가는 것이 안전하다.</li>
+  </ul>
+  <div class="callout teal">
+    <span class="label">마지막 요약</span>
+    <p>이 프로젝트의 LLM은 "눈"(차트 모양 인식)과 "계산기"(숫자 규칙 실행)를 겸직하고 있다. 계산기 일은 코드에게 돌려주자. <strong>C는 통째로, B는 정량 조건을, A는 정량 게이트를.</strong> 그러면 LLM은 진짜 잘하는 일 — 모양을 보고, 경계를 판단하고, 사람에게 설명하는 일 — 에만 집중하게 된다.</p>
+  </div>
+</section>
+
+<footer>
+  <span>kr-by-claude 리뷰 시리즈 1/4 — LLM 결정론적 분리</span>
+  <span>다음: 02 LLM 효율화 방안</span>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/artifacts/2026-07-08-llm-review-series/02-llm-efficiency.html
+++ b/docs/artifacts/2026-07-08-llm-review-series/02-llm-efficiency.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LLM 효율화 방안 — kr-by-claude 리뷰 시리즈 2/4</title>
+<style>
+  :root {
+    --paper: #f7f3ea;
+    --paper-deep: #efe8d8;
+    --ink: #2b2620;
+    --ink-soft: #5c544a;
+    --accent: #8a3324;
+    --accent-soft: #f3e0da;
+    --teal: #1f5f5b;
+    --teal-soft: #dcebe9;
+    --gold: #a07d2a;
+    --gold-soft: #f2ead2;
+    --line: #d8cfbd;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--paper);
+    background-image: radial-gradient(circle at 85% 6%, rgba(160,125,42,.06), transparent 40%),
+                      radial-gradient(circle at 10% 95%, rgba(31,95,91,.05), transparent 45%);
+    color: var(--ink);
+    font-family: "Apple SD Gothic Neo", "Noto Sans KR", "Pretendard", sans-serif;
+    line-height: 1.75;
+    font-size: 16.5px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 0 28px 120px; }
+  header.masthead { padding: 72px 0 40px; border-bottom: 3px double var(--ink); margin-bottom: 8px; }
+  .series-tag {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .18em;
+    text-transform: uppercase; color: var(--accent);
+    display: inline-block; border: 1px solid var(--accent);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 24px;
+  }
+  h1 {
+    font-family: "Nanum Myeongjo", "Apple SD Gothic Neo", serif;
+    font-size: clamp(30px, 5vw, 44px);
+    font-weight: 800; line-height: 1.3; margin-bottom: 18px;
+  }
+  h1 em { font-style: normal; color: var(--accent); }
+  .dek { font-size: 18px; color: var(--ink-soft); max-width: 42em; }
+  .byline { margin-top: 22px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); }
+  nav.toc { margin: 36px 0 56px; padding: 22px 26px; background: var(--paper-deep); border-left: 4px solid var(--ink); }
+  nav.toc strong { display:block; font-size: 13px; letter-spacing:.12em; margin-bottom: 10px; }
+  nav.toc ol { margin-left: 20px; }
+  nav.toc a { color: var(--ink); text-decoration: none; border-bottom: 1px dotted var(--ink-soft); }
+  nav.toc a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  section { margin-bottom: 72px; }
+  h2 {
+    font-family: "Nanum Myeongjo", serif; font-size: 27px; font-weight: 800;
+    margin-bottom: 6px; display: flex; align-items: baseline; gap: 14px;
+  }
+  h2 .no {
+    font-family: var(--mono); font-size: 15px; color: var(--accent);
+    border: 1.5px solid var(--accent); border-radius: 50%;
+    width: 32px; height: 32px; flex: 0 0 32px;
+    display: inline-flex; align-items: center; justify-content: center;
+    transform: translateY(-2px);
+  }
+  h3 { font-size: 19px; margin: 34px 0 10px; }
+  .rule { width: 64px; height: 3px; background: var(--accent); margin: 14px 0 22px; }
+  p { margin-bottom: 16px; max-width: 46em; }
+  ul, ol { margin: 0 0 18px 24px; }
+  li { margin-bottom: 8px; max-width: 44em; }
+  code { font-family: var(--mono); font-size: .85em; background: var(--paper-deep); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--line); }
+  .callout { margin: 26px 0; padding: 20px 24px; border-radius: 6px; background: var(--accent-soft); border-left: 4px solid var(--accent); }
+  .callout.teal { background: var(--teal-soft); border-left-color: var(--teal); }
+  .callout.gold { background: var(--gold-soft); border-left-color: var(--gold); }
+  .callout .label { font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase; display: block; margin-bottom: 8px; }
+  .callout p:last-child { margin-bottom: 0; }
+  .badge { display: inline-block; font-family: var(--mono); font-size: 11px; letter-spacing: .06em; padding: 2px 9px; border-radius: 999px; vertical-align: 1px; white-space: nowrap; }
+  .badge.done { background: var(--teal); color: #fff; }
+  .badge.todo { background: var(--accent); color: #fff; }
+  .badge.exp  { background: var(--gold); color: #fff; }
+  .tbl-scroll { overflow-x: auto; margin: 22px 0; border: 1px solid var(--line); border-radius: 8px; background: #fffdf7; }
+  table { border-collapse: collapse; width: 100%; font-size: 14.5px; min-width: 640px; }
+  th { text-align: left; font-size: 12px; letter-spacing: .08em; padding: 12px 16px; background: var(--paper-deep); border-bottom: 2px solid var(--ink); white-space: nowrap; }
+  td { padding: 12px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  .stat-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; margin: 26px 0; }
+  .stat {
+    background: #fffdf7; border: 1.5px solid var(--ink); border-radius: 10px;
+    padding: 18px 20px; box-shadow: 4px 4px 0 rgba(43,38,32,.10);
+  }
+  .stat .v { font-family: "Nanum Myeongjo", serif; font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1.15; }
+  .stat .k { font-size: 12.5px; color: var(--ink-soft); margin-top: 6px; line-height: 1.5; }
+  .idea {
+    border: 1.5px solid var(--ink); border-radius: 10px; background: #fffdf7;
+    margin: 26px 0; overflow: hidden; box-shadow: 5px 5px 0 rgba(43,38,32,.10);
+  }
+  .idea .head { padding: 15px 22px; background: var(--ink); color: var(--paper); display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px; }
+  .idea .head h3 { margin: 0; font-size: 16.5px; color: var(--paper); }
+  .idea .body { padding: 20px 22px; }
+  .idea .meta { font-family: var(--mono); font-size: 11px; opacity: .8; }
+  .rank { counter-reset: rk; margin: 26px 0; }
+  .rank .item { display: flex; gap: 18px; padding: 20px 0; border-bottom: 1px solid var(--line); }
+  .rank .item::before {
+    counter-increment: rk; content: counter(rk);
+    font-family: "Nanum Myeongjo", serif; font-size: 34px; font-weight: 800;
+    color: var(--accent); line-height: 1; flex: 0 0 36px;
+  }
+  .rank .item h4 { font-size: 16.5px; margin-bottom: 6px; }
+  .rank .item p { font-size: 14.5px; color: var(--ink-soft); margin-bottom: 0; }
+  footer { margin-top: 90px; padding-top: 24px; border-top: 3px double var(--ink); font-family: var(--mono); font-size: 12px; color: var(--ink-soft); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+  .fade { animation: fadeUp .7s ease both; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(14px);} to { opacity: 1; transform: none;} }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead fade">
+  <span class="series-tag">kr-by-claude 리뷰 시리즈 · 2 / 4</span>
+  <h1>LLM을 <em>더 싸고 더 빠르게</em><br>쓰는 방법</h1>
+  <p class="dek">LLM 호출 비용과 속도는 결국 "몇 번 부르는가 × 한 번에 얼마나 주고받는가"로 정해진다. 이 프로젝트는 이미 큰 최적화를 한 차례 끝냈다(토큰 −77~83%). 이 문서는 지금 상태를 숫자로 보여주고, 남은 개선 카드를 효과·위험과 함께 초보자 눈높이로 정리한다.</p>
+  <p class="byline">작성 2026-07-08 밤 · 실측 근거: achart_v3_speed_report.md(45런) + freeze 아티팩트 + DB 기록 컬럼</p>
+</header>
+
+<nav class="toc fade">
+  <strong>차례</strong>
+  <ol>
+    <li><a href="#basics">기초: 토큰이 왜 돈이고 왜 속도인가</a></li>
+    <li><a href="#now">지금 얼마나 쓰고 있나 — 실측</a></li>
+    <li><a href="#done">이미 해놓은 최적화 (건드리지 말 것)</a></li>
+    <li><a href="#calls">개선 축 ① 호출 횟수 줄이기</a></li>
+    <li><a href="#input">개선 축 ② 한 번에 보내는 양 줄이기</a></li>
+    <li><a href="#speed">개선 축 ③ 더 빨리 끝내기</a></li>
+    <li><a href="#priority">권장 우선순위와 검증 방법</a></li>
+  </ol>
+</nav>
+
+<section id="basics" class="fade">
+  <h2><span class="no">1</span>기초: 토큰이 왜 돈이고 왜 속도인가</h2>
+  <div class="rule"></div>
+  <p><strong>토큰(token)</strong>은 LLM이 글을 세는 단위다. 대략 영어 단어 하나가 1~2토큰, 숫자가 빽빽한 JSON은 글자 수의 ¼~⅓ 정도가 토큰이 된다. LLM 요금은 "들어간 토큰(입력) + 나온 토큰(출력)"에 비례하고, <strong>응답 속도는 특히 출력 토큰 수에 크게 좌우</strong>된다 — LLM은 출력을 한 토큰씩 생성하기 때문이다. 입력이 아무리 커도 읽는 건 비교적 빠르지만, 긴 답을 쓰게 하면 그만큼 오래 걸린다.</p>
+  <p>알아둘 개념이 하나 더 있다. <strong>프롬프트 캐시(prompt cache)</strong>: 같은 앞부분(예: 매번 똑같은 577줄짜리 지시문)을 반복해서 보내면, LLM 서버가 그 부분을 기억해뒀다가 재사용한다. 캐시에서 읽는 토큰은 정가의 약 1/10 가격이다. 이 프로젝트가 쓰는 <code>claude</code> CLI는 이걸 자동으로 해준다.</p>
+  <div class="callout">
+    <span class="label">효율의 3축</span>
+    <p>결국 손댈 곳은 세 군데뿐이다. <strong>① 호출 횟수</strong>(안 불러도 되는 건 안 부르기), <strong>② 호출당 주고받는 양</strong>(입력 다이어트, 출력 상한), <strong>③ 시간 구조</strong>(병렬로 돌리기, 빠른 모델 쓰기). 아래 개선 카드는 전부 이 3축으로 분류된다.</p>
+  </div>
+</section>
+
+<section id="now" class="fade">
+  <h2><span class="no">2</span>지금 얼마나 쓰고 있나 — 실측</h2>
+  <div class="rule"></div>
+  <p>비용의 압도적 대부분은 <strong>사이트 A(차트 분류)</strong>에서 나온다. B(매수 타이밍)는 짧은 지시문에 작은 JSON만 보내는 경량 호출이고, C(매수 파라미터)는 지시문이 A의 75% 크기라 짧지는 않지만 <strong>호출 자체가 드물어서</strong>(B가 "지금 매수"로 판정한 날만) 총비용 비중이 작다.</p>
+  <div class="stat-row">
+    <div class="stat"><div class="v">~10.7만</div><div class="k">사이트 A 호출 1건당 총 처리 토큰 (캐시 생성 7.6만 + 캐시 읽기 1.6만 + 신규 입력 0.8만 + 출력 0.7만)</div></div>
+    <div class="stat"><div class="v">130~224초</div><div class="k">사이트 A 종목 1개 분석 소요 시간 (런 그룹별 중앙값 밴드, 개별 런은 97~251초)</div></div>
+    <div class="stat"><div class="v">~2.6만</div><div class="k">A 인라인 페이로드(숫자 데이터+CSV) 텍스트 토큰 추정 — 지시문(~1.3만)보다 데이터가 더 크다</div></div>
+    <div class="stat"><div class="v">~3천</div><div class="k">차트 PNG 2장(1400×900px)의 이미지 토큰</div></div>
+  </div>
+  <p>구성을 뜯어보면 이렇다. 사이트 A 호출 한 번에 들어가는 것:</p>
+  <ul>
+    <li><strong>지시문</strong> — <code>analyze_chart_v3.md</code> 577줄 (~1.2만~1.5만 토큰). 매번 동일 → 캐시가 흡수.</li>
+    <li><strong>숫자 데이터</strong> — payload.json(60일 일봉 + 104주 주봉 + 지표 20컬럼 60일치 + 시장 맥락) + daily/weekly CSV + 시장지수 CSV 2개. 합쳐서 텍스트 ~10.4만 글자 ≈ 2.6만 토큰. <strong>종목마다 다르므로 캐시 불가.</strong></li>
+    <li><strong>차트 이미지 2장</strong> — 일봉·주봉 PNG, 합계 ~3천 토큰.</li>
+    <li><strong>출력</strong> — 분류·패턴·측정치·한국어 근거문(1500자 제한). 현행 설정 실측 약 7,200~16,900 토큰. 중요한 사실: 이 중 눈에 보이는 답(JSON+근거문)은 2~4천 토큰 정도고, <strong>대부분은 모델이 답하기 전에 하는 내부 사고(thinking)</strong>다 — 인라인 전환 전 진단 런 기준으로 종목당 234초 중 ~160초가 thinking이었다.</li>
+  </ul>
+  <div class="callout teal">
+    <span class="label">좋은 소식: 측정 인프라가 이미 있다</span>
+    <p>모든 프로덕션 호출은 실제 사용 모델·입력/출력 토큰·소요 시간을 DB 컬럼(<code>llm_model</code>, <code>llm_input_tokens</code>, <code>llm_output_tokens</code>, <code>llm_call_duration_s</code>)에 기록한다. 즉 "지난달 실제로 얼마 썼나"는 SQL 한 방이면 나온다. 어떤 최적화든 <strong>이 실측 기록으로 전/후를 비교</strong>하면 된다.</p>
+  </div>
+</section>
+
+<section id="done" class="fade">
+  <h2><span class="no">3</span>이미 해놓은 최적화 (건드리지 말 것)</h2>
+  <div class="rule"></div>
+  <p>"개선하자"가 "이미 있는 걸 다시 만들자"가 되지 않도록, 현재 갖춰진 장치를 먼저 인정하고 가자.</p>
+  <div class="tbl-scroll"><table>
+    <thead><tr><th>장치</th><th>무엇을 아끼나</th><th>비고</th></tr></thead>
+    <tbody>
+      <tr><td><strong>인라인 방식 전환</strong> <span class="badge done">완료</span></td><td>대화 턴 8~12회 → 1회, 토큰 −77~83%</td><td>과거엔 ZIP을 주고 LLM이 파일을 하나씩 열어봤다. 지금은 본문에 데이터를 인라인으로 붙여 한 번에 준다. 45런 실측으로 판정 불변(45/45) 확인 후 채택.</td></tr>
+      <tr><td><strong>결정론 선(先)게이트</strong> <span class="badge done">완료</span></td><td>호출 수</td><td>스크리너 통과분만 A 호출, 돌파 후보 선별기(trigger_gate)를 통과한 종목만 B 호출, B가 "지금 매수"로 판정한 건(go_now)만 C 호출.</td></tr>
+      <tr><td><strong>중복 호출 방지</strong> <span class="badge done">완료</span></td><td>호출 수</td><td>주말 재실행 시 기적재분 skip, 평일 7일 내 기분류 skip, abort 재발화 skip.</td></tr>
+      <tr><td><strong>사용량 한도 즉시 중단</strong> <span class="badge done">완료</span></td><td>헛 호출</td><td>5시간 사용량 한도에 걸리면 재시도 없이 배치 전체를 멈춘다.</td></tr>
+      <tr><td><strong>출력 길이 상한</strong> <span class="badge done">완료</span></td><td>출력 토큰·속도</td><td>근거문 A는 1500자, B는 200자 제한. C는 경고 개수 ≤6.</td></tr>
+      <tr><td><strong>주말 병렬 4워커</strong> <span class="badge done">완료</span></td><td>벽시계 시간</td><td><code>WEEKEND_CONCURRENCY</code> 기본 4, 스레드풀.</td></tr>
+    </tbody>
+  </table></div>
+</section>
+
+<section id="calls" class="fade">
+  <h2><span class="no">4</span>개선 축 ① 호출 횟수 줄이기</h2>
+  <div class="rule"></div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 1 — 사이트 C를 결정론 함수로 대체</h3><span class="meta">효과 大 · 위험 小 <span class="badge todo">권장</span></span></div>
+    <div class="body"><p>시리즈 1편의 결론과 동일하다. C는 계산 절차서를 LLM이 실행하는 구조라, 결정론 함수로 바꾸면 <strong>go_now 1건당 LLM 호출 1회가 통째로 사라진다</strong>. 토큰 절감이자 속도 개선(수십 초 → 수 밀리초)이며 품질도 오히려 오른다.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 2 — 사이트 B에 "명백 케이스" 사전 판정</h3><span class="meta">효과 中 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p>go_now의 정량 조건(거래량 1.4배 등)을 코드가 먼저 계산해서, <strong>명백히 미달인 날은 LLM을 부르지 않고 wait 처리</strong>하는 아이디어다. 단, 알아야 할 배경이 있다: 현재의 결정론 게이트가 거래량 하한을 1.4가 아니라 1.0배로 잡은 것은 실수가 아니라 <strong>의도된 설계</strong>다 — "정밀 임계와 예외 판단은 LLM 몫"이라고 주석에 명시돼 있고, 게이트를 책 기준(1.4×)에 딱 맞추면 pocket pivot처럼 거래량이 기준에 못 미쳐도 정당한 예외인 돌파를 기계적으로 죽이게 된다.</p>
+    <p>따라서 이 카드는 "1.4× 미달이면 자르기"가 아니라, <strong>예외 패턴까지 명시적으로 통과시키는 조건 설계 + 과거 데이터로 false negative(잘못 걸러진 정당한 돌파) 0건 확인</strong>을 통과해야만 도입할 수 있다. 절감량(트리거는 걸렸지만 조건이 한참 모자랐던 날의 비율)도 DB 기록으로 먼저 세어보고 결정.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 3 — 주말 분류의 "변화 없음" 스킵 검토</h3><span class="meta">효과 大 가능성 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p>주말 배치는 스크리너 통과 종목을 매주 전부 재분류한다. 그런데 지난주와 차트가 거의 안 변한 종목(예: 주간 변동 미미, 거래량 평이, 베이스 진행 중)은 지난주 분류가 그대로 유효할 가능성이 높다. <strong>"주간 변화량이 임계 이하면 지난주 분류를 이월"</strong>하는 결정론 룰을 만들면 주말 호출 수를 크게 줄일 수 있다.</p>
+    <p>단, 위험이 있다: 베이스는 "조용히 성숙"하기 때문에 가격 변화가 작아도 분류가 바뀌어야 할 때가 있다(예: 핸들 완성). 그래서 이월 규칙은 보수적으로 — 이월은 최대 N주까지, watch→entry 승격은 이월 불가 등 — 설계하고, 과거 데이터로 "이월했더라면 틀렸을 주"가 몇 %인지 백테스트한 뒤 도입해야 한다.</p></div>
+  </div>
+</section>
+
+<section id="input" class="fade">
+  <h2><span class="no">5</span>개선 축 ② 한 번에 보내는 양 줄이기</h2>
+  <div class="rule"></div>
+  <p>사이트 A의 입력 ~2.6만 토큰(캐시 불가능한, 종목마다 다른 부분)이 표적이다. 여기서 아끼는 토큰은 매 호출 온전히 아껴진다.</p>
+
+  <div class="idea">
+    <div class="head"><h3>카드 4 — 페이로드 중복 제거 확대</h3><span class="meta">효과 中 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p>현재 인라인 페이로드에는 <strong>같은 정보가 두 번 들어가는 곳</strong>이 있다: payload.json 안에 일봉 60일·주봉 104주가 JSON으로 들어 있는데, 별도로 daily.csv(60일)·weekly.csv(104주)도 붙는다. 설계 당시 "CSV를 빼면 late_stage_base(베이스가 이미 여러 차례 반복된 늦은 단계라는 위험 플래그) 판정이 나빠질 우려"로 보존을 택했다(market_context.json만 중복 제거됨). 이제 45런 검증 방법론이 확립됐으니, <strong>CSV 제거 vs 보존을 같은 방식(판정 불변 검사)으로 실험</strong>해볼 가치가 있다. 성공하면 입력의 상당 부분이 사라진다.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 5 — 지표 테이블 다이어트</h3><span class="meta">효과 中 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p><code>indicators_recent_60d</code>는 지표 20컬럼 × 60일이다. LLM이 실제로 참조하는 컬럼(프롬프트가 언급하는 SMA, RS line, pocket pivot, 분배일 플래그 등)만 남기고 나머지를 빼거나, 숫자의 소수 자릿수를 줄이는 것만으로도 토큰이 준다. 프롬프트가 요구하지 않는 컬럼부터 빼는 것이 안전하다.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 6 — 이미지 해상도 실험</h3><span class="meta">효과 小 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p>차트 PNG 2장은 ~3천 토큰으로, 입력 전체에서 비중이 작다. 1400×900을 낮추면 절감은 소소한데 <strong>시각 판단(핸들·수축 인식) 품질이 떨어질 위험</strong>은 실재한다. 우선순위 낮음 — 다른 카드를 다 쓴 뒤에나 고려.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 7 — 진짜 속도 레버: thinking 예산 조절 실험</h3><span class="meta">효과 大 가능성 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p>출력 실측이 약 7,200~16,900 토큰인데, §2에서 봤듯 이 대부분은 눈에 보이는 답이 아니라 <strong>모델의 내부 사고(thinking)</strong>다. 속도 실측(인라인 전환 전 진단 런 기준)에서도 종목당 234초 중 ~160초가 thinking 구간이었고 런별 편차(50~160초)의 주 원인도 이것이었다. 즉 measurements나 근거문을 다이어트해봤자 속도는 거의 안 잡힌다 — <strong>출력과 시간의 주범은 thinking이고, 조절 레버는 thinking(effort) 예산</strong>이다.</p>
+    <p>이것은 기존 속도 리포트가 "본 측정에서는 제외"라고 명시하고 남겨둔 미개척 영역이다. thinking을 줄이면 시각 판단 품질이 떨어질 위험이 실재하므로, 반드시 판정 불변 검사(45/45 방식)를 통과해야 채택한다. 통과한다면 이 카드 하나가 시간·출력 토큰 모두에서 가장 큰 효과를 낼 수 있다.</p></div>
+  </div>
+</section>
+
+<section id="speed" class="fade">
+  <h2><span class="no">6</span>개선 축 ③ 더 빨리 끝내기</h2>
+  <div class="rule"></div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 8 — 평일 경로도 병렬화</h3><span class="meta">효과 中 · 위험 小 <span class="badge todo">권장</span></span></div>
+    <div class="body"><p>주말 배치는 4워커 병렬인데, <strong>평일 경로(daily_delta·evaluate_pivot·entry_params)는 전부 순차 for 루프</strong>다. 주말용으로 이미 만들어진 병렬 실행기(<code>parallel.py</code> — 재시도·중단 처리 포함)를 평일 경로에 재사용하면, 코드 추가 거의 없이 평일 벽시계 시간이 워커 수만큼 줄어든다. 평일 종목 수가 적은 날은 효과가 작지만, 몰리는 날의 지연을 없애준다.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 9 — 워커 수 상향 실험</h3><span class="meta">효과 中 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p><code>WEEKEND_CONCURRENCY=4</code>는 보수적 기본값이다. 6~8로 올리면 주말 배치가 그만큼 빨라질 수 있지만, 두 가지를 관찰해야 한다: ① 동시 호출이 늘면 5시간 사용량 한도에 더 빨리 도달한다(총량은 같지만 소진 속도가 빨라짐), ② 호출당 지연이 늘어나는지(<code>llm_call_duration_s</code>로 확인). 한 단계씩 올리며 실측.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 10 — 사이트 B에 더 작고 빠른 모델</h3><span class="meta">효과 中 · 위험 中 <span class="badge exp">실험 필요</span></span></div>
+    <div class="body"><p>모델은 <code>KR_CLAUDE_MODEL</code> 환경변수로 핀돼 있어 오프라인 실험은 쉽다. 다만 이 변수는 프로세스 전역이고 평일 실행은 A/B/C를 한 프로세스에서 순차 호출하므로, <strong>B만 다른 모델을 실제 적용하려면 호출 함수에 모델 파라미터를 추가하는 소규모 코드 변경</strong>이 따른다. A(차트 시각 판단)는 상위 모델이 필요하지만, <strong>B는 숫자 JSON을 규칙 대조하는 경량 판정</strong>이라 더 작고 빠른 모델로도 충분할 수 있다. 검증 방법은 이미 확립돼 있다: 과거 저장된 판정과의 일치율 비교(analyze_chart의 Sonnet 전환 때 20건 신뢰성 + 일치율 검증을 했던 것과 같은 절차). 단, 카드 2(명백 케이스 사전 판정)와 카드 1(C 결정론화)을 먼저 하면 B에 남는 건 경계 판단뿐이라, 그때는 오히려 상위 모델 유지가 맞을 수도 있다 — 순서를 지켜서 판단.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 11 — 캐시 온기 유지 (알아두면 좋은 상식 수준)</h3><span class="meta">효과 小 · 위험 無</span></div>
+    <div class="body"><p>프롬프트 캐시는 기본 설정 기준 <strong>약 5분</strong>이 지나면 식는다. 배치가 연속으로 돌면 두 번째 호출부터 지시문(1.2만+ 토큰)을 캐시에서 싸게 읽는다. 다행히 현재 구조에서는 손실이 잘 안 난다 — 평일 경로도 호출이 연달아(back-to-back) 이어지는 순차 루프라 보통 5분 안에 다음 호출이 나가고, 세 단계는 각자 다른 지시문을 쓰므로 단계 사이의 캐시 공유는 애초에 시스템 프롬프트 정도다. 실제 손실은 <strong>후보가 아주 적어 호출 간격이 벌어지는 날</strong> 정도에 국한된다. 별도 작업이 필요한 카드가 아니라, 배치 구조를 바꿀 때 "실행 밀도가 캐시 온기"라는 사실만 기억하면 되는 항목.</p></div>
+  </div>
+
+  <div class="idea">
+    <div class="head"><h3>카드 12 — 에이전트 부팅 다이어트 (실측 완료·보류 중인 옵션)</h3><span class="meta">효과 小~中 · 위험 小 <span class="badge exp">재검토</span></span></div>
+    <div class="body"><p>A 호출 1건의 캐시 생성 ~7.6만 토큰에는 지시문·데이터 외에 <strong>claude CLI가 에이전트를 띄우면서 얹는 시스템 오버헤드</strong>(툴 정의, 세션 장치 등)가 포함된다. 과거 속도 리포트는 이걸 줄인 변형(안전모드·세션 저장 생략 등, "AB 변형")까지 실측해뒀다: <strong>현행 방식 대비 토큰 −27%(10.7만→7.9만), 비용 −9%, 종목별 중앙값 합 −3%</strong>. 품질(판정)은 동일했고 "당장은 보류 가능"으로 남겨졌다. 참고로 그중 일부(도구를 Read 하나로 제한)는 이미 프로덕션에 적용돼 있다. 시간 단축 효과는 미미하고(이상치 포함 전체 벽시계는 오히려 밀린 런도 있었다) <strong>본질은 토큰·비용 절감 카드</strong>다 — 카드 1~8을 소화한 뒤에도 비용이 아까우면, 새로 실험할 것 없이 이미 측정이 끝난 이 옵션을 꺼내 쓰면 된다.</p></div>
+  </div>
+</section>
+
+<section id="priority" class="fade">
+  <h2><span class="no">7</span>권장 우선순위와 검증 방법</h2>
+  <div class="rule"></div>
+  <div class="rank">
+    <div class="item"><div>
+      <h4>측정 대시보드부터 (반나절)</h4>
+      <p>DB에 이미 쌓인 <code>llm_*</code> 컬럼으로 "사이트별 호출 수 × 평균 토큰 × 평균 시간" 현황표를 만든다. 모든 카드의 효과는 이 표의 전/후 비교로 판정한다. 측정 없는 최적화는 하지 않는다.</p>
+    </div></div>
+    <div class="item"><div>
+      <h4>확실한 것 먼저: 카드 1 (C 결정론화) + 카드 8 (평일 병렬화)</h4>
+      <p>둘 다 품질 하락 위험이 사실상 없고 효과가 구조적이다. 카드 1은 시리즈 1편의 이행 계획을 그대로 따른다.</p>
+    </div></div>
+    <div class="item"><div>
+      <h4>호출 수 공략: 카드 2 → 카드 3</h4>
+      <p>둘 다 과거 데이터로 절감량과 부작용(false negative)을 먼저 세어보고 결정한다. 카드 3(변화 없음 이월)은 효과가 가장 클 수 있지만 백테스트 검증이 선행돼야 한다.</p>
+    </div></div>
+    <div class="item"><div>
+      <h4>콜당 다이어트 실험: 카드 4 → 카드 5 → 카드 7, 필요하면 카드 9·10·12</h4>
+      <p>입력·출력을 건드리는 카드(4·5·6·7)는 "판정 불변 검사"(같은 종목 세트에서 전/후 분류 일치 확인 — speed report의 45/45 방식)를 통과해야 채택. 카드 10(B 모델 교체)은 B의 판정 일치율 비교로 검증. 카드 9(워커 수)는 판정과 무관하니 지연·한도 소진 속도만 관찰. 카드 6(이미지 축소)은 마지막까지 아껴두고, 카드 12는 이미 실측이 끝나 있어 필요할 때 꺼내 쓰면 된다.</p>
+    </div></div>
+  </div>
+  <div class="callout teal">
+    <span class="label">한 줄 요약</span>
+    <p>이 프로젝트의 효율화는 "프롬프트를 짧게 쓰자" 수준의 이야기가 아니라 이미 한 차례 정밀 최적화를 거친 시스템의 2라운드다. 남은 큰 덩어리는 <strong>① 안 불러도 되는 호출을 없애는 것(카드 1·2·3), ② 캐시가 못 흡수하는 종목별 데이터를 다이어트하는 것(카드 4·5), ③ 순차 구간을 병렬화하는 것(카드 8), ④ 시간과 출력의 실제 주범인 thinking 예산을 실험하는 것(카드 7)</strong>이다. 그리고 무엇을 하든, 45런 판정-불변 검증과 DB 실측 비교라는 이 프로젝트의 기존 검증 문화를 그대로 따르면 된다.</p>
+  </div>
+</section>
+
+<footer>
+  <span>kr-by-claude 리뷰 시리즈 2/4 — LLM 효율화</span>
+  <span>이전: 01 결정론적 분리 · 다음: 03 모순 검토</span>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/artifacts/2026-07-08-llm-review-series/03-contradictions.html
+++ b/docs/artifacts/2026-07-08-llm-review-series/03-contradictions.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>분석 체계 모순 검토 — kr-by-claude 리뷰 시리즈 3/4</title>
+<style>
+  :root {
+    --paper: #f7f3ea;
+    --paper-deep: #efe8d8;
+    --ink: #2b2620;
+    --ink-soft: #5c544a;
+    --accent: #8a3324;
+    --accent-soft: #f3e0da;
+    --teal: #1f5f5b;
+    --teal-soft: #dcebe9;
+    --gold: #a07d2a;
+    --gold-soft: #f2ead2;
+    --line: #d8cfbd;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--paper);
+    background-image: radial-gradient(circle at 50% 4%, rgba(138,51,36,.05), transparent 40%),
+                      radial-gradient(circle at 8% 90%, rgba(31,95,91,.05), transparent 45%);
+    color: var(--ink);
+    font-family: "Apple SD Gothic Neo", "Noto Sans KR", "Pretendard", sans-serif;
+    line-height: 1.75; font-size: 16.5px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 0 28px 120px; }
+  header.masthead { padding: 72px 0 40px; border-bottom: 3px double var(--ink); margin-bottom: 8px; }
+  .series-tag {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .18em; text-transform: uppercase;
+    color: var(--accent); display: inline-block; border: 1px solid var(--accent);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 24px;
+  }
+  h1 { font-family: "Nanum Myeongjo", serif; font-size: clamp(30px, 5vw, 44px); font-weight: 800; line-height: 1.3; margin-bottom: 18px; }
+  h1 em { font-style: normal; color: var(--accent); }
+  .dek { font-size: 18px; color: var(--ink-soft); max-width: 42em; }
+  .byline { margin-top: 22px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); }
+  nav.toc { margin: 36px 0 56px; padding: 22px 26px; background: var(--paper-deep); border-left: 4px solid var(--ink); }
+  nav.toc strong { display:block; font-size: 13px; letter-spacing:.12em; margin-bottom: 10px; }
+  nav.toc ol { margin-left: 20px; }
+  nav.toc a { color: var(--ink); text-decoration: none; border-bottom: 1px dotted var(--ink-soft); }
+  nav.toc a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  section { margin-bottom: 72px; }
+  h2 { font-family: "Nanum Myeongjo", serif; font-size: 27px; font-weight: 800; margin-bottom: 6px; display: flex; align-items: baseline; gap: 14px; }
+  h2 .no {
+    font-family: var(--mono); font-size: 15px; color: var(--accent);
+    border: 1.5px solid var(--accent); border-radius: 50%;
+    width: 32px; height: 32px; flex: 0 0 32px;
+    display: inline-flex; align-items: center; justify-content: center; transform: translateY(-2px);
+  }
+  .rule { width: 64px; height: 3px; background: var(--accent); margin: 14px 0 22px; }
+  p { margin-bottom: 16px; max-width: 46em; }
+  ul, ol { margin: 0 0 18px 24px; }
+  li { margin-bottom: 8px; max-width: 44em; }
+  code { font-family: var(--mono); font-size: .85em; background: var(--paper-deep); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--line); }
+  .callout { margin: 26px 0; padding: 20px 24px; border-radius: 6px; background: var(--accent-soft); border-left: 4px solid var(--accent); }
+  .callout.teal { background: var(--teal-soft); border-left-color: var(--teal); }
+  .callout.gold { background: var(--gold-soft); border-left-color: var(--gold); }
+  .callout .label { font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase; display: block; margin-bottom: 8px; }
+  .callout p:last-child { margin-bottom: 0; }
+  .sev { display: inline-block; font-family: var(--mono); font-size: 11px; letter-spacing: .06em; padding: 2px 9px; border-radius: 999px; color:#fff; vertical-align: 2px; white-space: nowrap; }
+  .sev.high { background: var(--accent); }
+  .sev.mid  { background: var(--gold); }
+  .sev.low  { background: #7a7263; }
+  .finding {
+    border: 1.5px solid var(--ink); border-radius: 10px; background: #fffdf7;
+    margin: 26px 0; overflow: hidden; box-shadow: 5px 5px 0 rgba(43,38,32,.10);
+  }
+  .finding .head { padding: 15px 22px; background: var(--ink); color: var(--paper); display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px; }
+  .finding .head h3 { margin: 0; font-size: 16.5px; color: var(--paper); }
+  .finding .body { padding: 20px 22px; }
+  .finding .scenario {
+    margin: 14px 0 6px; padding: 14px 18px; border-radius: 6px;
+    background: var(--paper-deep); border-left: 3px solid var(--gold);
+    font-size: 14.5px;
+  }
+  .finding .scenario .t { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--gold); display:block; margin-bottom: 6px; }
+  .finding .fix { font-size: 14.5px; color: var(--teal); margin-top: 10px; }
+  .finding .fix::before { content: "고치는 방향 — "; font-weight: 700; }
+  .tbl-scroll { overflow-x: auto; margin: 22px 0; border: 1px solid var(--line); border-radius: 8px; background: #fffdf7; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; min-width: 640px; }
+  th { text-align: left; font-size: 12px; letter-spacing: .08em; padding: 12px 16px; background: var(--paper-deep); border-bottom: 2px solid var(--ink); white-space: nowrap; }
+  td { padding: 11px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  footer { margin-top: 90px; padding-top: 24px; border-top: 3px double var(--ink); font-family: var(--mono); font-size: 12px; color: var(--ink-soft); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+  .fade { animation: fadeUp .7s ease both; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(14px);} to { opacity: 1; transform: none;} }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead fade">
+  <span class="series-tag">kr-by-claude 리뷰 시리즈 · 3 / 4</span>
+  <h1>분석 체계에 <em>모순</em>은 없는가</h1>
+  <p class="dek">규칙이 많아지면 규칙끼리 부딪히기 시작한다. 이 문서는 스크리너·프롬프트·게이트·저장 코드 전체를 라인 단위로 맞대보고, "서로 반대말을 하는 곳"을 찾아낸 감사 보고서다. 확정 모순 8건, 조건부 모순 8건, 그리고 감시망의 구멍 하나를 발견했다 — 동시에, 점검했지만 멀쩡했던 것들도 함께 기록한다.</p>
+  <p class="byline">작성 2026-07-08 밤 · 방법: 적대적 정합성 감사 (코드·프롬프트 실라인 대조 + drift 테스트 실행)</p>
+</header>
+
+<nav class="toc fade">
+  <strong>차례</strong>
+  <ol>
+    <li><a href="#why">모순은 왜 생기나</a></li>
+    <li><a href="#confirmed">확정 모순 8건</a></li>
+    <li><a href="#conditional">조건부 모순 8건</a></li>
+    <li><a href="#coverage">감시망의 구멍 — drift 테스트가 못 보는 곳</a></li>
+    <li><a href="#clean">점검했지만 멀쩡했던 것들</a></li>
+    <li><a href="#priority">수리 우선순위</a></li>
+  </ol>
+</nav>
+
+<section id="why" class="fade">
+  <h2><span class="no">1</span>모순은 왜 생기나</h2>
+  <div class="rule"></div>
+  <p>이 시스템의 규칙은 세 곳에 나뉘어 산다: <strong>① 임계값 정의 파일</strong>(<code>thresholds.py</code> — 단일 출처), <strong>② LLM에게 주는 지시문</strong>(프롬프트 .md 4개 — <em>수동</em> 동기화), <strong>③ 파이썬 코드</strong>(게이트·저장·페이로드). 셋 중 프롬프트만 사람이 손으로 맞춰줘야 해서, 규칙이 바뀔 때마다 어긋날 기회가 생긴다.</p>
+  <p>실제로 이번에 발견된 모순 대부분은 두 종류다:</p>
+  <ul>
+    <li><strong>버전 업의 잔재</strong> — 프롬프트를 v2.0에서 v2.1로 올리면서 옛 문단을 지우지 않아, 한 문서가 옛말과 새말을 동시에 하는 경우.</li>
+    <li><strong>같은 개념의 두 정의</strong> — 예를 들어 "분배일"이나 "불량 핸들"을 프롬프트와 코드가 서로 다른 수식으로 정의한 경우.</li>
+  </ul>
+  <div class="callout">
+    <span class="label">읽는 법</span>
+    <p><strong>확정 모순</strong>은 지금 이 순간에도 성립하는 불일치다. <strong>조건부 모순</strong>은 특정 상황(특정 시장 상태, 특정 패턴)이 와야 충돌이 드러나는 것이다. 각 항목에는 "충돌 시나리오"(무슨 일이 실제로 벌어지나)와 "고치는 방향"을 달았다. 용어가 낯설면 1편(결정론적 분리)의 용어 정리를 참고 — pivot(돌파 기준가), payload(LLM 입력 데이터 묶음), 분배일(거래량 실린 하락일), §번호(프롬프트 파일의 절 번호).</p>
+  </div>
+</section>
+
+<section id="confirmed" class="fade">
+  <h2><span class="no">2</span>확정 모순 8건</h2>
+  <div class="rule"></div>
+
+  <div class="finding">
+    <div class="head"><h3>A — 매수 파라미터 프롬프트가 "존재하지 않는 입력"을 참조한다</h3><span class="sev high">심각도 상</span></div>
+    <div class="body">
+      <p>매수 파라미터 프롬프트(C, <code>calculate_entry_params_v2_0.md</code>)에는 입력 정의 섹션이 <strong>두 개</strong> 있다 — 옛 버전(v2.0)과 새 버전(v2.1). 실제 payload와 일치하는 건 v2.1뿐인데, 옛 섹션을 근거로 한 규칙들이 그대로 살아 있다. 그 결과 다섯 갈래의 문제 — 존재하지 않는 필드를 가리키는 "유령 참조" 3건과, 문서가 스스로 반대말을 하는 상호 모순 2건 — 가 생겼다:</p>
+      <ul>
+        <li>에코 검증 대상 키를 <code>current_metrics.close</code>라고 지시하는데 실제 키는 <code>current_state.close</code>다 (알려진 네이밍 drift — 이번에 재확인).</li>
+        <li>"가장 먼저 실행하라"는 §0.5(pocket pivot 진입 모드 감지)가 <code>prior_analysis.reasoning</code>을 파싱하라는데, <strong>이 필드는 C의 payload에 아예 안 들어간다.</strong> 즉 pocket pivot 분기 전체(손절·비중·거래량 규칙 4개 절 + 경고 코드 2종)가 구조적으로 도달 불가능한 죽은 규칙이다. A 프롬프트가 "reasoning에 pocket_pivot_entry를 명기하라"고 강제하는 이유(하류에서 읽기 위해)도 함께 무효화돼 있다.</li>
+        <li>비중 사이징 티어가 참조하는 <code>prior_analysis.confidence</code>도 payload에 없다 — 사이징 규칙의 핵심 입력이 유령이다.</li>
+        <li>한 문단은 "market_context가 payload에 포함된다", 다른 문단은 "이 단계는 market_context를 받지 않는다"고 말한다. 실제는 후자.</li>
+        <li>"여기 도달하는 분류는 항상 entry"라는 문장은, watch 종목도 breakout_from_watch로 도달한다는 같은 문서의 예외 규정과 정면 충돌한다.</li>
+      </ul>
+      <div class="scenario"><span class="t">충돌 시나리오</span>LLM이 지시대로 없는 필드를 찾다가 스스로 추측으로 메꾸거나(각 실행마다 다르게), pocket pivot 종목이 표준 규칙으로 사이징된다. 규칙이 안 지켜져도 아무 경고가 없다 — 죽은 규칙은 조용히 죽어 있다.</div>
+      <p class="fix">v2.0 입력 섹션 삭제, §0.5가 필요하면 reasoning(또는 전용 플래그)을 payload에 실제로 추가, confidence도 마찬가지. 1편의 결론(C 결정론화)을 실행하면 이 문제 전체가 근본적으로 소멸한다.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>B — "분배일"의 정의가 프롬프트와 코드에서 다르다</h3><span class="sev high">심각도 상</span></div>
+    <div class="body">
+      <p>A 프롬프트는 종목 분배일을 "<strong>0.2% 이상</strong> 하락 + 거래량 1.0배 초과"로 정의하고, "이 플래그 컬럼이 권위 있는 값이니 재계산하지 말라"고 명시한다. 그런데 그 컬럼을 실제로 계산하는 코드는 <strong>0% 컷</strong>(어제보다 조금이라도 내리면 하락)을 쓴다. 즉 −0.1% 하락한 날도 분배일로 집계된다.</p>
+      <p>과거에는 "LLM이 텍스트 정의대로 재계산하니 자연히 −0.2%가 적용된다"는 논리로 정당화됐지만, 프롬프트가 "컬럼이 권위, 재계산 금지"로 바뀐 순간 그 정당화는 무효가 됐다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>분배일 카운트가 책 정의보다 과대 집계 → "분배일 4개 이상이면 watch로 강등" 룰과, topping(고점에서 힘이 빠지며 하락 전환하는 국면 — 강제 ignore 사유 중 하나) 판정 규칙이 실제보다 공격적으로 발화. 핸들 품질 게이트(핸들 안 분배일 1개면 발화)도 같은 과대 플래그를 소비한다.</div>
+      <p class="fix">계산 코드에 −0.2% 컷을 넣거나, 프롬프트 정의를 0% 컷으로 고치거나 — 어느 쪽이든 <strong>한 정의로 통일</strong>. (책 기준은 −0.2% 쪽이다.)</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>C — 리스크 플래그 개수가 세 곳에서 다르다 (14 vs 15)</h3><span class="sev mid">심각도 중</span></div>
+    <div class="body">
+      <p>플래그 목록의 진짜 정답은 코드의 <strong>15종</strong>이다. A 프롬프트의 표도 15종을 나열하는데, 같은 문서의 다른 두 문장은 "14개 값만 쓰라"고 말한다. 더 나쁜 것은 수동 검증용 프롬프트(<code>verify_analysis_v1.md</code>)의 "전수 점검" 목록이 14개뿐이라 <strong><code>topping_distribution</code>을 아예 모른다</strong>는 점 — 분석가가 이 플래그를 빠뜨려도 검증자가 잡을 수 없는 검증 사각이다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>topping 관련 강제-ignore 축이 검증 범위 밖에 놓인다. "전수 점검했다"는 검증 결과가 실제로는 1종을 못 본 결과가 된다.</div>
+      <p class="fix">세 곳 모두 15로 통일하고, verify 프롬프트 목록에 topping_distribution 추가.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>D — pivot_basis: 규칙 표가 시키는 값을 출력 스키마가 금지한다</h3><span class="sev mid">심각도 중</span></div>
+    <div class="body">
+      <p>A 프롬프트 §4.7의 표는 희귀 패턴 4종(high_tight_flag 등)에 대해 <code>top_of_flag</code>, <code>cheat_pivot</code> 같은 pivot_basis 값을 쓰라고 정의하는데, 출력 스키마의 허용 목록에는 4개 값(<code>handle_high / range_high / final_T_high / mid_W_peak</code>)뿐이다. 이 패턴들에서는 <strong>표를 따르면 스키마 위반, 스키마를 따르면 표 위반</strong>이라 둘 다 지킬 수 없다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>희귀 패턴 종목에서 LLM이 실행마다 다른 쪽을 선택 → 저장 값 비일관. (저장은 문자열을 그대로 받아주므로 에러도 안 난다.)</div>
+      <p class="fix">스키마 enum(허용값을 고정해 둔 목록)에 4개 값을 추가하거나, §4.7 표를 스키마의 4값 체계로 재작성.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>E — A는 9개 패턴을 알지만 C는 5개만 받아준다</h3><span class="sev mid">심각도 중</span></div>
+    <div class="body">
+      <p>A는 high_tight_flag, base_on_base, ascending_base 패턴으로도 entry 분류를 낼 수 있다. 이 종목이 돌파해서 C(매수 파라미터)에 도달하면: C의 기본 규칙은 "A의 패턴을 그대로 써라"인데, C의 검증 절은 "패턴은 정확히 5개 중 하나여야 한다"며 이 3개를 안 받아준다. <code>none</code>일 때의 폴백 규정만 있고 이 3개 패턴의 처리 규정은 없다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>희귀 패턴 종목이 go_now(B 단계의 "지금 매수" 판정)까지 갔을 때 C가 규칙 충돌 상태에서 임의로 5개 중 하나로 구겨 넣는다 — 비중 티어가 잘못된 패턴 기준으로 계산될 수 있다.</div>
+      <p class="fix">C의 패턴 목록에 3종을 추가(각자 비중 티어 규정과 함께)하거나, "목록 밖 패턴은 none 취급" 폴백을 명문화.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>F — 주말과 평일의 "후보 자격"이 다르다</h3><span class="sev mid">심각도 중</span></div>
+    <div class="body">
+      <p>주말 배치의 후보 조건은 "스크리너 통과 <strong>그리고</strong> RS line(주가÷지수 — 시장 대비 상대 강도 곡선)이 7개월간 하락 추세가 아닐 것(= 시장에 뒤처지는 laggard 종목 배제) <strong>그리고</strong> 거래정지 아님"이다. 그런데 평일 신규 감지(daily_delta)는 <strong>스크리너 통과만</strong> 본다. 같은 시스템이 "laggard는 후보가 아니다"(토요일)와 "laggard도 후보다"(평일)를 동시에 주장하는 셈이다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>RS line이 7개월째 하락 중인 종목이 월요일에 스크리너를 통과하면 평일 경로로 분류·모니터링 풀에 들어온다 — 토요일이었다면 문 앞에서 걸러졌을 종목이다.</div>
+      <p class="fix">daily_delta의 후보 SQL에 주말과 같은 두 조건을 추가 (한 곳에서 공유 조건으로 정의하면 재발도 방지된다).</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>G — 본문 규칙은 1.5배인데 예시는 1.4배를 보여준다</h3><span class="sev mid">심각도 중하</span></div>
+    <div class="body">
+      <p>C 프롬프트 본문은 표준 패턴의 돌파 거래량 요구치를 1.4배에서 <strong>1.5배로 상향</strong>했다(P0-1 결정). 그런데 문서 끝의 예시 답안 두 개가 여전히 <strong>1.4배</strong>를 보여준다. LLM은 예시(few-shot)를 본문 규칙만큼, 때로는 그 이상으로 따라 하므로, 예시가 규칙 상향을 조용히 되돌리는 편향 경로가 된다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>실행마다 1.4와 1.5 사이에서 흔들리는 출력 — P0-1 상향이 확률적으로 무력화.</div>
+      <p class="fix">예시 2곳의 값을 1.5배로 갱신. (교훈: 임계 변경 체크리스트에 "예시 JSON도 갱신" 항목 추가.)</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>H — 자잘한 개수·참조 drift 3건</h3><span class="sev low">심각도 하</span></div>
+    <div class="body">
+      <ul>
+        <li>C 프롬프트: 경고 코드 화이트리스트를 한 곳은 "15개", 다른 곳은 "16개"라 부른다 — 실제 표는 16개.</li>
+        <li>C 프롬프트: 출력 "17개 필드" 헤더 — 실제 스키마는 18개.</li>
+        <li>B 프롬프트: abort 사유 카탈로그의 실제 위치는 §3.4인데, 두 곳에서 §3.3(실제로는 promotion 절)으로 잘못 가리킨다.</li>
+      </ul>
+      <p class="fix">숫자·참조 일괄 정정. 사소해 보여도 "몇 개 중에서 고르라"는 지시가 흔들리면 LLM 출력도 흔들린다.</p>
+    </div>
+  </div>
+</section>
+
+<section id="conditional" class="fade">
+  <h2><span class="no">3</span>조건부 모순 8건</h2>
+  <div class="rule"></div>
+  <p>특정 상태가 와야 드러나는 충돌들이다. 가장 위험한 I부터.</p>
+
+  <div class="finding">
+    <div class="head"><h3>I — "시장 불리" 강등의 회복 게이트가 강등 사유를 재확인하지 않는다</h3><span class="sev high">심각도 상 (조건부)</span></div>
+    <div class="body">
+      <p>A는 시장이 상승 확인 상태여도 <strong>분배일이 5개 이상이면</strong> "시장 여건 불리"로 watch 강등할 수 있다. 그런데 그 종목이 나중에 돌파했을 때 B의 회복 판정은 <strong>"시장 상태 = 상승 확인"만</strong> 본다 — 분배일 수는 다시 안 센다. 분배일 5개는 상승 확인 상태와 공존 가능하므로(6개부터 상태가 바뀜), <strong>강등 사유가 그대로인 날에도 go_now("지금 매수" 판정)가 통과</strong>할 수 있다. 한 술 더 떠 C는 "go_now로 왔다는 것 자체가 시장 회복의 증거"라며 이 경로의 보수화 조치(비중 절반, 목표 하향 등)를 전부 면제한다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>분배일 5개로 강등된 종목이, 분배일이 여전히 5개인 다음 주에 돌파 → 보수화 없는 풀사이즈 매수 파라미터 발급. 강등이 무의미해지는 순간.</div>
+      <p class="fix">B의 unfavorable_market 회복 조건에 "분배일 수가 강등 임계 아래로 내려왔는가"를 추가.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>J — "불량 핸들"의 두 정의 (프롬프트 절대치 vs 게이트 상대치)</h3><span class="sev mid">심각도 중 (조건부)</span></div>
+    <div class="body">
+      <p>프롬프트는 핸들 불량을 절대 깊이(&gt;12% 등)로 판정하고, 결정론 게이트는 <strong>상대 비율</strong>(핸들 깊이가 컵 깊이의 33% 초과 등)로 재판정한다. 얕은 컵(깊이 15%)에 얕은 핸들(6%)이 달리면 — 프롬프트로는 합격인데 게이트 비율(40%)로는 불합격이라 entry가 watch로 강등된다. 이 미봉합은 <code>thresholds.py</code> 주석에 "reconcile 미완"이라고 스스로 적혀 있는, <strong>알려진 부채</strong>다. 게이트의 "핸들 내 분배일 1개면 발화" 규칙도 프롬프트의 "분배일 하루는 정상" 문구와 결이 다르고, B번 모순(0% 컷 과대 플래그)과 결합하면 발화 확률이 한층 부풀려진다.</p>
+      <p class="fix">두 정의의 관계를 명시적으로 결정(게이트는 보수적 백스톱이므로 의도적 비대칭일 수 있다 — 그렇다면 그 의도를 문서화하고 얕은-컵 케이스의 오발화만 보정).</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>K — 백스톱이 강등한 레코드는 그 자체로 모순 상태가 되어 하류에 흘러간다</h3><span class="sev mid">심각도 중 (조건부)</span></div>
+    <div class="body">
+      <p>결정론 백스톱이 entry를 watch로 강등하면: 근거문(reasoning)은 entry 논리 그대로, 분류는 watch, watch 사유는 (의도적으로) 비움, 근거문에 없는 플래그가 추가돼 있음 — 이 조합은 A 프롬프트 자신의 불가침 룰("근거문과 플래그 정합", "watch면 사유 필수")을 위반하는 상태다. 문제는 이 자기모순 레코드가 <strong>다음 단계 B의 입력으로 그대로 들어간다</strong>는 것.</p>
+      <p class="fix">강등 시 reasoning에 강등 사실을 덧붙이는 후처리 한 줄(예: "[게이트 강등: handle_quality]")로 레코드 내부 정합을 회복.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>L — 기업행위(증자 등) 가격 재조정이 pivot에는 적용되지 않는다</h3><span class="sev mid">심각도 중 (조건부)</span></div>
+    <div class="body">
+      <p>증자·분할 같은 기업행위가 생기면 가격 히스토리는 재정규화되지만, 이미 저장된 분류의 <code>pivot_price</code>·<code>base_low</code>를 함께 환산하는 코드는 없다(전체 검색 0건). 분류 시점과 다음 주말 사이에 기업행위가 끼면, 트리거 게이트가 <strong>서로 다른 조정 기준의 가격끼리</strong> 비교하게 된다.</p>
+      <div class="scenario"><span class="t">충돌 시나리오</span>허위 invalidation(베이스가 무너졌다는 오판 → 그 종목 셋업을 폐기하는 abort 판정에 고착) 또는 허위 breakout(돌파 오판). 노출 창은 주말 재분류까지 최대 1주.</div>
+      <p class="fix">기업행위 drift 처리에 "활성 분류의 가격 레벨 rescale" 단계 추가, 또는 최소한 해당 종목 트리거 평가를 재분류 전까지 보류.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>M~P — 나머지 4건 (심각도 하, 요약표)</h3><span class="sev low">심각도 하 (조건부)</span></div>
+    <div class="body">
+      <div class="tbl-scroll"><table>
+        <thead><tr><th>#</th><th>내용</th><th>고치는 방향</th></tr></thead>
+        <tbody>
+          <tr><td><strong>M</strong></td><td>시장 상태 "rally_attempt"에 FTD(추세 확인일)가 <em>있는</em> 변종이 존재하는데, A의 하드캡 문구는 "FTD 없는 rally_attempt"만 지칭 — 경계가 어긋남.</td><td>하드캡 문구를 상태값 기준으로 재정의.</td></tr>
+          <tr><td><strong>N</strong></td><td>"여유 3% 미만" 마진 룰이 이질 단위를 한 잣대로 잼 — 어떤 조건의 마진은 %가 아니라 포인트차, 어떤 조건은 상시 3% 미만이라 룰이 의도보다 쉽게 발화.</td><td>조건별 마진 단위 정규화 또는 조건별 임계.</td></tr>
+          <tr><td><strong>O</strong></td><td>규정 공백 2건: 분배일 정확히 4개인 시장(5≥불리, ≤3 정상 사이), 거래량 1.2배 미만 돌파(1.4↑ go, 1.2~1.4 wait만 규정).</td><td>경계값 명시 (아마 각각 "정상"과 "wait").</td></tr>
+          <tr><td><strong>P</strong></td><td>watch 출신 돌파는 시장 회복을 요구받는데, entry 출신 돌파의 go_now 조건에는 시장 확인이 아예 없음 — 분류 후 주중에 시장이 꺾여도 막는 규칙이 없다.</td><td>§3.1에도 시장 상태 가드 추가 여부를 정책으로 결정.</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+  </div>
+</section>
+
+<section id="coverage" class="fade">
+  <h2><span class="no">4</span>감시망의 구멍 — drift 테스트가 못 보는 곳</h2>
+  <div class="rule"></div>
+  <p>프롬프트와 임계값 정의의 어긋남을 감시하는 자동 테스트(<code>test_prompt_threshold_drift.py</code>)는 존재하고, 실행하면 통과한다(2 passed). 문제는 <strong>커버리지</strong>다: 이 테스트가 보는 것은 A 프롬프트의 SSOT 블록 안 16개 상수뿐이다.</p>
+  <ul>
+    <li><strong>B·C 프롬프트는 통째로 미감시</strong> — 1.4배, 손절 −7%/−5.5%/−10%, 비중 15/10/7/5% 등 전부 수동 동기.</li>
+    <li><strong>A 프롬프트의 블록 밖 자유텍스트 수치</strong>(분배일 ≥5, 마진 3%, ±5% 밴드 등)도 미감시.</li>
+  </ul>
+  <p>이번에 발견된 G(예시 1.4 vs 본문 1.5)가 정확히 이 사각에서 발생했다. 모순을 하나하나 고치는 것과 별개로, <strong>사각을 줄이는 투자(테스트 확장)</strong>가 재발 방지책이다.</p>
+  <div class="callout gold">
+    <span class="label">좋은 소식</span>
+    <p>이 감시망 확장은 이미 시작돼 있다 — drift 감시를 프롬프트 3개 전체로 넓히는 <strong>PR #5</strong>가 현재 오픈 상태로 리뷰 대기 중이다. 머지되면 이 절의 사각 중 상당 부분이 닫힌다 (예시 JSON까지 커버하는지는 머지 전 확인 권장 — G가 정확히 예시에서 났다).</p>
+  </div>
+</section>
+
+<section id="clean" class="fade">
+  <h2><span class="no">5</span>점검했지만 멀쩡했던 것들</h2>
+  <div class="rule"></div>
+  <p>감사의 절반은 "의심했지만 무죄"를 기록하는 일이다. 원 감사에서 15개 항목을 점검해 정합을 확인했고, 아래에 9갈래로 묶어 기록한다:</p>
+  <ul>
+    <li>SSOT 블록 16개 상수 ↔ A 프롬프트 (테스트 PASS), UI용 생성 파일(thresholds.generated.ts)도 재생성 diff 0.</li>
+    <li>스크리너 조건 배수들(C6 ×1.25, C7 ×0.75, C8 ≥70 등) — 코드·프롬프트 일치.</li>
+    <li>promotion 경계 0.95 ↔ ±5% 밴드 하한 ↔ B의 promotion 규정 — 3자 정합. promotion에서 go_now 금지도 프롬프트+SQL 이중 방어.</li>
+    <li>watch_reason 5종 enum ↔ 트리거 게이트 허용 3종 — 나머지 2종 제외는 의도적 설계(도달 불능 아님).</li>
+    <li>게이트 1.0배(느슨) vs LLM 1.4배(정밀) — 문서화된 의도적 분업, 모순 아님 (2편 카드 2 참조).</li>
+    <li>돌파 거래량 임계 체계(1.4 floor / 1.5 preferred) — 값 자체는 3문서 정합 (G의 예시 문제와 별개).</li>
+    <li>verdict 규율: ignore는 climax(수직 과열 급등의 정점)/topping/reverse-split(액면병합) 3종뿐 — 4곳 모두 일관, 플래그 누적으로 ignore 되는 뒷문 없음.</li>
+    <li>B용 payload는 프롬프트와 키가 정확히 일치 (C payload의 유령 필드 문제는 B에는 없음).</li>
+    <li>2E_tier2 차단, 평일 실행 순서(자격상실→신규→트리거→파라미터), failed_breakout 기록 범위, "8조건 항상 true" 전제 — 모두 정합.</li>
+  </ul>
+  <div class="callout teal">
+    <span class="label">균형 잡힌 결론</span>
+    <p>골격 — 스크리너, 임계 SSOT, 게이트 철학, verdict 규율 — 은 튼튼하다. 모순은 주로 <strong>수동 동기화 구간</strong>(프롬프트 문서 내부, 프롬프트↔payload, 프롬프트↔지표 계산)에 몰려 있다. 이는 1편의 결론(정량 규칙의 결정론화)이 품질 문제이기도 하다는 뜻이다: 규칙이 코드로 내려오면 이런 부류의 모순은 컴파일러와 테스트가 잡는다.</p>
+  </div>
+</section>
+
+<section id="priority" class="fade">
+  <h2><span class="no">6</span>수리 우선순위</h2>
+  <div class="rule"></div>
+  <ol>
+    <li><strong>A (유령 입력) + I (강등 역류)</strong> — 실거래 파라미터에 직결되는 두 건부터. A는 v2.0 섹션 삭제 + payload 필드 결정, I는 회복 게이트에 분배일 재확인 한 줄.</li>
+    <li><strong>B (분배일 정의 통일)</strong> — 강등·강제-ignore 축 전체에 영향을 주는 상류 결함. −0.2% 컷으로 코드 수정이 책 정합.</li>
+    <li><strong>G + H + C + D + E (문서 drift 일괄)</strong> — 전부 프롬프트 텍스트 수정이라 한 PR로 묶어 처리 가능. 처리하면서 4번 절의 drift 테스트 확장(B·C 프롬프트, 예시 JSON 포함)을 같이.</li>
+    <li><strong>F (평일 후보 조건)</strong> — SQL 조건 추가, 작지만 정책 확인 필요(평일에도 laggard 배제가 맞는지 한 번 결정).</li>
+    <li><strong>J·K·L·M~P</strong> — 각각 독립 소규모. L(기업행위 rescale)은 발생 빈도는 낮지만 발생 시 피해가 커서 J·K보다 먼저 볼 가치.</li>
+  </ol>
+  <div class="callout">
+    <span class="label">주의</span>
+    <p>이 중 임계값이나 그 소비처를 건드리는 수리(B, I, J 등)는 프로젝트 규칙대로 <code>threshold-change-checklist.md</code>의 의존성 맵(2축 판정)을 먼저 작성해야 한다 — 모순을 고치다 새 모순을 만드는 것이 이 계열 작업의 고전적 함정이다.</p>
+  </div>
+</section>
+
+<footer>
+  <span>kr-by-claude 리뷰 시리즈 3/4 — 모순 검토</span>
+  <span>이전: 02 효율화 · 다음: 04 비효율 검토</span>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/artifacts/2026-07-08-llm-review-series/04-inefficiencies.html
+++ b/docs/artifacts/2026-07-08-llm-review-series/04-inefficiencies.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>분석 체계 비효율 검토 — kr-by-claude 리뷰 시리즈 4/4</title>
+<style>
+  :root {
+    --paper: #f7f3ea;
+    --paper-deep: #efe8d8;
+    --ink: #2b2620;
+    --ink-soft: #5c544a;
+    --accent: #8a3324;
+    --accent-soft: #f3e0da;
+    --teal: #1f5f5b;
+    --teal-soft: #dcebe9;
+    --gold: #a07d2a;
+    --gold-soft: #f2ead2;
+    --line: #d8cfbd;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--paper);
+    background-image: radial-gradient(circle at 20% 5%, rgba(31,95,91,.06), transparent 40%),
+                      radial-gradient(circle at 92% 88%, rgba(138,51,36,.05), transparent 45%);
+    color: var(--ink);
+    font-family: "Apple SD Gothic Neo", "Noto Sans KR", "Pretendard", sans-serif;
+    line-height: 1.75; font-size: 16.5px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 0 28px 120px; }
+  header.masthead { padding: 72px 0 40px; border-bottom: 3px double var(--ink); margin-bottom: 8px; }
+  .series-tag {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .18em; text-transform: uppercase;
+    color: var(--accent); display: inline-block; border: 1px solid var(--accent);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 24px;
+  }
+  h1 { font-family: "Nanum Myeongjo", serif; font-size: clamp(30px, 5vw, 44px); font-weight: 800; line-height: 1.3; margin-bottom: 18px; }
+  h1 em { font-style: normal; color: var(--accent); }
+  .dek { font-size: 18px; color: var(--ink-soft); max-width: 42em; }
+  .byline { margin-top: 22px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); }
+  nav.toc { margin: 36px 0 56px; padding: 22px 26px; background: var(--paper-deep); border-left: 4px solid var(--ink); }
+  nav.toc strong { display:block; font-size: 13px; letter-spacing:.12em; margin-bottom: 10px; }
+  nav.toc ol { margin-left: 20px; }
+  nav.toc a { color: var(--ink); text-decoration: none; border-bottom: 1px dotted var(--ink-soft); }
+  nav.toc a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  section { margin-bottom: 72px; }
+  h2 { font-family: "Nanum Myeongjo", serif; font-size: 27px; font-weight: 800; margin-bottom: 6px; display: flex; align-items: baseline; gap: 14px; }
+  h2 .no {
+    font-family: var(--mono); font-size: 15px; color: var(--accent);
+    border: 1.5px solid var(--accent); border-radius: 50%;
+    width: 32px; height: 32px; flex: 0 0 32px;
+    display: inline-flex; align-items: center; justify-content: center; transform: translateY(-2px);
+  }
+  .rule { width: 64px; height: 3px; background: var(--accent); margin: 14px 0 22px; }
+  p { margin-bottom: 16px; max-width: 46em; }
+  ul, ol { margin: 0 0 18px 24px; }
+  li { margin-bottom: 8px; max-width: 44em; }
+  code { font-family: var(--mono); font-size: .85em; background: var(--paper-deep); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--line); }
+  .callout { margin: 26px 0; padding: 20px 24px; border-radius: 6px; background: var(--accent-soft); border-left: 4px solid var(--accent); }
+  .callout.teal { background: var(--teal-soft); border-left-color: var(--teal); }
+  .callout.gold { background: var(--gold-soft); border-left-color: var(--gold); }
+  .callout .label { font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase; display: block; margin-bottom: 8px; }
+  .callout p:last-child { margin-bottom: 0; }
+  .badge { display: inline-block; font-family: var(--mono); font-size: 11px; letter-spacing: .06em; padding: 2px 9px; border-radius: 999px; color:#fff; vertical-align: 2px; white-space: nowrap; }
+  .badge.sure { background: var(--accent); }
+  .badge.cond { background: var(--gold); }
+  .badge.minor{ background: #7a7263; }
+  .badge.pr   { background: var(--teal); }
+  .finding {
+    border: 1.5px solid var(--ink); border-radius: 10px; background: #fffdf7;
+    margin: 26px 0; overflow: hidden; box-shadow: 5px 5px 0 rgba(43,38,32,.10);
+  }
+  .finding .head { padding: 15px 22px; background: var(--ink); color: var(--paper); display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px; }
+  .finding .head h3 { margin: 0; font-size: 16.5px; color: var(--paper); }
+  .finding .body { padding: 20px 22px; }
+  .finding .fix { font-size: 14.5px; color: var(--teal); margin-top: 10px; }
+  .finding .fix::before { content: "고치는 방향 — "; font-weight: 700; }
+  .stat-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 14px; margin: 26px 0; }
+  .stat { background: #fffdf7; border: 1.5px solid var(--ink); border-radius: 10px; padding: 18px 20px; box-shadow: 4px 4px 0 rgba(43,38,32,.10); }
+  .stat .v { font-family: "Nanum Myeongjo", serif; font-size: 28px; font-weight: 800; color: var(--accent); line-height: 1.15; }
+  .stat .k { font-size: 12.5px; color: var(--ink-soft); margin-top: 6px; line-height: 1.5; }
+  .tbl-scroll { overflow-x: auto; margin: 22px 0; border: 1px solid var(--line); border-radius: 8px; background: #fffdf7; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; min-width: 640px; }
+  th { text-align: left; font-size: 12px; letter-spacing: .08em; padding: 12px 16px; background: var(--paper-deep); border-bottom: 2px solid var(--ink); white-space: nowrap; }
+  td { padding: 11px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  footer { margin-top: 90px; padding-top: 24px; border-top: 3px double var(--ink); font-family: var(--mono); font-size: 12px; color: var(--ink-soft); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+  .fade { animation: fadeUp .7s ease both; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(14px);} to { opacity: 1; transform: none;} }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead fade">
+  <span class="series-tag">kr-by-claude 리뷰 시리즈 · 4 / 4</span>
+  <h1>어디서 <em>새고</em> 있는가<br>— 비효율 검토</h1>
+  <p class="dek">이번 편은 LLM 밖의 이야기다. 매일 도는 데이터 파이프라인, cron 스케줄, 디스크, 그리고 사람 손이 반복하는 일 — 여기서 낭비되는 컴퓨트·시간·저장공간을 찾아냈다. 반가운 사실 하나: 가장 큰 발견 3건은 이미 오픈 PR로 수리 대기 중이었다.</p>
+  <p class="byline">작성 2026-07-08 밤 · 방법: 코드 정독 + 설치된 crontab 실물 + 디스크 실측 (모순·LLM 토큰 최적화는 2·3편에서 기감사, 여기선 제외)</p>
+</header>
+
+<nav class="toc fade">
+  <strong>차례</strong>
+  <ol>
+    <li><a href="#big">큰 그림: 네 갈래의 낭비</a></li>
+    <li><a href="#compute">파이프라인 컴퓨트 — 반복 낭비</a></li>
+    <li><a href="#schedule">스케줄 구조 — 헛돌거나, 시간 갭에 기대거나</a></li>
+    <li><a href="#dead">죽은 무게 — 스토리지와 잔존물</a></li>
+    <li><a href="#toil">사람 손 — 반복 수작업</a></li>
+    <li><a href="#clean">효율적이라고 확인한 것들</a></li>
+    <li><a href="#priority">우선순위 요약</a></li>
+  </ol>
+</nav>
+
+<section id="big" class="fade">
+  <h2><span class="no">1</span>큰 그림: 네 갈래의 낭비</h2>
+  <div class="rule"></div>
+  <p>이 시스템은 매일 저녁 ~2,550개 전 종목의 시세를 갱신하고 지표를 계산한 뒤, 소수 후보만 LLM으로 보낸다. 낭비는 주로 "전 종목을 상대하는 앞단"에서 발생한다. 크게 네 갈래다:</p>
+  <div class="stat-row">
+    <div class="stat"><div class="v">~7,600회</div><div class="k">하루에 나가는 외부 API 호출 (KRX ~5,100 + DART ~2,500) — 대부분 "변한 게 없다"는 답을 받으러 간다</div></div>
+    <div class="stat"><div class="v">~21만 행</div><div class="k">하루에 다시 쓰는 DB 행 버전 — 실제 신규는 ~2,550행, 나머지 ~99%는 기존 행 재기록(대부분 같은 값으로 추정 — 미측정)</div></div>
+    <div class="stat"><div class="v">106MB</div><div class="k">무한 증가 중인 freeze 보관함 (1,236개) — 청소 코드는 완성돼 있는데 실행 주체가 없었다</div></div>
+    <div class="stat"><div class="v">연 ~12일</div><div class="k">휴장일에도 헛도는 전체 파이프라인 (거래일 게이트 부재)</div></div>
+  </div>
+  <div class="callout teal">
+    <span class="label">먼저 알아둘 것 — 이미 수리가 시작된 항목들</span>
+    <p>이 감사의 상위 발견 중 3건은 <strong>이미 오픈 PR로 리뷰 대기 중</strong>이다: DART 호출 일괄화(<strong>PR #13</strong>), freeze 청소 스케줄 편입(<strong>PR #11</strong>), 테스트 baseline 0화(<strong>PR #12</strong>). 리포 잔존물의 .gitignore 정리도 <strong>PR #4</strong>로 나와 있다. 아래에서는 해당 항목에 PR 배지를 달아 표시한다 — <strong>이들의 최우선 액션은 "새 작업"이 아니라 "리뷰하고 머지"</strong>다.</p>
+  </div>
+</section>
+
+<section id="compute" class="fade">
+  <h2><span class="no">2</span>파이프라인 컴퓨트 — 반복 낭비</h2>
+  <div class="rule"></div>
+
+  <div class="finding">
+    <div class="head"><h3>C1 — 같은 KOSPI 지수를 종목마다 다시 읽는다</h3><span><span class="badge sure">확실</span></span></div>
+    <div class="body">
+      <p>일봉 지표 계산은 종목별 루프인데, 모든 종목에 공통인 <strong>KOSPI 지수 시계열을 루프 안에서</strong> 매번 DB에서 다시 읽는다(<code>indicators/modes.py:141</code>). 하루에 같은 쿼리 ~2,550회, 중복 전송 ~74만 행. 주봉 체인도 같은 패턴이다.</p>
+      <p class="fix">루프 진입 전에 한 번 읽어 인자로 전달. 몇 줄짜리 수정으로 하루 DB 왕복 2,550회가 사라진다.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>C2 — 30일치를 매일 4중으로 다시 쓰는 지표 테이블</h3><span><span class="badge cond">조건부</span></span></div>
+    <div class="body">
+      <p>일봉 지표 증분은 안전마진으로 <strong>최근 30일 창</strong>을 다시 계산하는데, 그 창의 ~5.3만 행에 매일 upsert(있으면 갱신·없으면 삽입) + RS UPDATE + 스크리너 UPDATE + 주봉 게이트 UPDATE의 <strong>4중 쓰기</strong>가 들어간다. 값이 어제와 같아도 무조건 재기록되는 구조라 하루 행 버전 ~21만 개가 생긴다(PostgreSQL은 UPDATE 때 행을 새로 쓰고 옛 행을 남기므로, 같은 값이어도 쓰기 비용이 든다). 그중 어느 비율이 실제 "같은 값 재기록"인지는 <strong>미측정</strong>이다 — RS 등급처럼 과거 날짜 값이 정당하게 매일 바뀌는 컬럼도 있다. DB는 자동 청소(VACUUM)로 버티지만 I/O는 매일 지불한다.</p>
+      <p><strong>트레이드오프</strong>: 30일 창은 늦은 데이터 정정을 흡수하는 보험이다. 다만 가격 정정은 이미 별도의 drift 경로가 전 기간 재적재로 처리하므로, 이 보험은 상당 부분 중복이다.</p>
+      <p class="fix">창을 5일 안팎으로 줄이거나, UPDATE에 "값이 실제로 달라졌을 때만" 가드(<code>IS DISTINCT FROM</code>)를 넣기. 안전마진 축소는 검토 후 결정.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>C3 — 시세 수신: 전 종목 × 2회 호출로 매일 30일치 재수신</h3><span><span class="badge cond">조건부</span></span></div>
+    <div class="body">
+      <p>매일 저녁 종목당 원시가+수정가 <strong>2회씩 ~5,100번의 KRX 호출</strong>로 각 30일치를 다시 받는다(신규는 사실상 1일치). pykrx에는 "날짜 하나로 전 종목 시세"를 받는 API도 있어서, 원시가 경로는 30일×2시장 ≈ <strong>60호출로 대체 가능</strong>하다. 수정가는 종목 단위 API뿐이라 부분 개선만 가능.</p>
+      <p class="fix">원시가만 날짜 단위 조회로 전환하는 부분 개선 검토. 수정가 갱신은 drift 경로 의존도를 높이는 설계 검토와 함께.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>C4 — 공시 수집: 종목별 2,500회 호출 → 기간 일괄 조회</h3><span><span class="badge sure">확실</span> <span class="badge pr">PR #13 대기</span></span></div>
+    <div class="body">
+      <p>매 평일 아침 활성 종목 각각에 DART 공시를 물어봐서 <strong>~2,500회 호출</strong>이 나가는데, 대부분 "조회 결과 없음" 응답이다. DART는 회사를 지정하지 않으면 기간 전체 공시를 한 번에(페이지당 100건) 주므로, 일일 증분은 <strong>1~수 회 호출</strong>이면 끝난다(5년 백필도 21청크) — 호출 ~99% 절감.</p>
+      <p class="fix">이미 PR #13(기간 일괄 조회 + 역매핑)이 나와 있다. 리뷰 후 머지.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>C5 — 토요일 전체 스윕과 자잘한 중복들</h3><span><span class="badge cond">조건부</span> <span class="badge minor">사소</span></span></div>
+    <div class="body">
+      <ul>
+        <li><strong>토요일 전체 스윕</strong> — 전 종목 수정가 재확인(sleep만 ~4분, 전체 수십 분). 평일 공시 기반 경로가 같은 기간을 커버하므로, 스윕이 잡는 것은 "공시가 놓친 경우"뿐. 안전망 가치는 있으니 주기 완화(격주/월간)나, 평일 경로가 못 보는 종목만 골라 도는 차집합 스윕으로.</li>
+        <li><strong>sanity 풀스캔</strong> — 적재 후 검증 COUNT 쿼리에 날짜 조건이 없어 매일 ~130만 행 테이블을 통째로 스캔. 이번 적재 범위로 WHERE 한정하면 끝(수정 극소).</li>
+        <li><strong>market_context</strong> — 매 저녁 30일×2지수를 date 루프로 재계산(실제 신규 2행). 신규 날짜만 처리로 전환 가능.</li>
+        <li><strong>평일 드리프트 이중 수신</strong> — 감지 단계에서 받은 수정가를 버리고 적재 단계에서 다시 받는다.</li>
+        <li><strong>빌더 이중 계산</strong> — LLM payload를 만들 때 minervini 상세·기업행위 블록을 두 번 계산.</li>
+        <li><strong>끝이 막힌 컬럼</strong> — 일봉 거래대금(value)은 주봉 value 집계에만 소비되는데, 정작 그 주봉 value를 읽는 곳이 없다(지수의 value는 LLM용 CSV로 소비되므로 예외). 사슬의 끝이 막혀 있는 셈. (stocks.listed_at 전체 NULL은 기지·보류.)</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="schedule" class="fade">
+  <h2><span class="no">3</span>스케줄 구조 — 헛돌거나, 시간 갭에 기대거나</h2>
+  <div class="rule"></div>
+
+  <div class="finding">
+    <div class="head"><h3>S1 — 휴장일에도 전체 체인이 돈다</h3><span><span class="badge sure">확실</span></span></div>
+    <div class="body">
+      <p>daily 체인(cron 평일 18:30)에 "오늘이 거래일인가" 확인이 없다. 설·추석·임시휴장 등 <strong>연 ~12일</strong>, KRX 호출 5,100번을 포함한 전체 체인(시세→지표→시장맥락→LLM 러너)이 아무 의미 없이 돈다. 거래일 판정 함수는 이미 코드에 있고 주봉 체인에서만 쓰인다.</p>
+      <p class="fix">체인 진입부에 거래일 가드 한 줄 (기존 <code>expected_latest_trading_day</code> 재사용).</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>S2 — 시간-갭 직렬화와 이중 실행</h3><span><span class="badge cond">조건부</span> <span class="badge minor">사소</span></span></div>
+    <div class="body">
+      <ul>
+        <li><strong>고정 시각 의존</strong> — 토요일 데이터 체인(03:00, 전체 스윕 포함 20~40분 추정)과 주말 LLM(03:20) 사이가 <strong>고정 20분 갭</strong>이다. 데이터가 늦게 끝나면 LLM이 덜 된 주봉을 읽고, 일찍 끝나면 시간을 버린다. 평일 18:30→19:30→20:00도 같은 구조.</li>
+        <li><strong>performance 이중 실행</strong> — 평일 20:00 통합 실행에 이미 포함된 성과 백필이 23:00에 또 돈다(주말 23:00은 신규 가격이 없어 아무 일도 안 하고 끝난다). 실비용은 미미하나 구조 정리 대상.</li>
+      </ul>
+      <p class="fix">후속 잡을 시각이 아니라 <strong>선행 잡 완료에 체이닝</strong>(데이터 체인 꼬리에 편입 or 성공 후 kick). performance는 한 곳만 남기기.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>S3 — dry-run 리허설이 freeze까지 저장한다</h3><span><span class="badge cond">조건부</span></span></div>
+    <div class="body">
+      <p>LLM 러너는 아직 실전 대기(dry-run) 상태인데, dry-run이어도 차트 렌더 + 인라인 빌드 + <strong>freeze ZIP 디스크 저장</strong>까지 전부 실행한다. 리허설로서 렌더·빌드는 가치가 있지만, <strong>재현할 분류가 없는 dry-run freeze</strong>는 보존 가치가 낮은 순수 낭비다 — 아래 D1의 106MB 중 상당수가 이것이다.</p>
+      <p class="fix">dry-run일 때 freeze 저장 skip (플래그 하나).</p>
+    </div>
+  </div>
+</section>
+
+<section id="dead" class="fade">
+  <h2><span class="no">4</span>죽은 무게 — 스토리지와 잔존물</h2>
+  <div class="rule"></div>
+
+  <div class="finding">
+    <div class="head"><h3>D1 — freeze 보관함 106MB, 무한 증가 중</h3><span><span class="badge sure">확실</span> <span class="badge pr">PR #11 대기</span></span></div>
+    <div class="body">
+      <p><code>data/freezes</code>가 1,236개·106MB로 증가 중(5월 165 → 6월 1,020개). 90일 보존·활성 보호 로직을 갖춘 청소 코드는 <strong>완성돼 있는데, 어떤 cron에도 등록돼 있지 않았다</strong>. 실행 주체 없는 청소부.</p>
+      <p class="fix">PR #11(스케줄 편입)이 이미 나와 있다. 리뷰 후 머지. S3(dry-run freeze skip)과 함께면 증가 속도 자체도 줄어든다.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>D2 — 리포와 스크립트의 잔존물</h3><span><span class="badge minor">사소</span> <span class="badge pr">PR #4 일부</span></span></div>
+    <div class="body">
+      <ul>
+        <li>워킹트리 방치물: 백테스트 산출물 디렉토리 6.8MB(평가 번들·리콜 CSV 등), expert-inquiry 자료, 속도 리포트, 주말 분류 CSV — 커밋/이동/삭제 결정 필요 (.gitignore 정리는 PR #4).</li>
+        <li>일회성 검증 스크립트 6종(특정 시점 리플레이·재측정) — 아카이브 이동 대상.</li>
+        <li><code>scripts/cron.example</code>이 현행 crontab과 다른 옛 구성을 안내 — 삭제하고 코드가 생성하는 목록을 정본으로.</li>
+        <li>run_tracking 테이블은 보존 정책 없음(하루 ~8행이라 당장 무해).</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="toil" class="fade">
+  <h2><span class="no">5</span>사람 손 — 반복 수작업</h2>
+  <div class="rule"></div>
+
+  <div class="finding">
+    <div class="head"><h3>T1 — "테스트 실패 ~25개는 원래 그래요"를 매번 사람이 센다</h3><span><span class="badge sure">확실</span> <span class="badge pr">PR #12 대기</span></span></div>
+    <div class="body">
+      <p>테스트 스위트에 격리 문제로 인한 baseline 실패가 ~25개 있어서, 모든 작업 세션이 "이번 실패 수가 늘었나?"를 눈으로 판독해왔다. 회귀 신호의 신호 대 잡음비를 갉아먹는 대표적 toil. 원인 진단(스키마 누수 + 죽은 테스트)은 이미 끝나 있었고, <strong>PR #12가 baseline을 0으로 만든다</strong>(그 과정에서 가짜 초록 2건도 발견됨).</p>
+      <p class="fix">PR #12 리뷰 후 머지 — 머지 후부터는 "실패 = 회귀"라는 단순 규칙이 성립한다.</p>
+    </div>
+  </div>
+
+  <div class="finding">
+    <div class="head"><h3>T2 — 손으로 맞추는 동기화 2종</h3><span><span class="badge cond">조건부</span></span></div>
+    <div class="body">
+      <ul>
+        <li><strong>schema.sql 이중 수동 적용</strong> — 스키마 변경 시 운영·테스트 두 DB에 각각 <code>psql -f</code>를 사람이 실행. 빠뜨리면 INSERT/테스트가 깨진다. 기동 시 버전 체크 또는 make 타겟 한 개로 해소 가능.</li>
+        <li><strong>임계값 3원 동기화</strong> — 임계 변경 시 UI 생성 스크립트 재실행과 프롬프트 문구 갱신이 수동. 전자는 pre-commit 훅으로 자동화 가능, 후자는 drift 테스트 확장(PR #5)이 감시망을 넓혀준다.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="clean" class="fade">
+  <h2><span class="no">6</span>효율적이라고 확인한 것들</h2>
+  <div class="rule"></div>
+  <p>이번에도 "의심했지만 무죄" 목록을 남긴다 — 다음 감사가 같은 곳을 다시 파지 않도록.</p>
+  <ul>
+    <li><strong>RS 등급 벌크 UPDATE</strong> — 행별 UPDATE가 아니라 임시 테이블 + JOIN 방식, 주석에 성능 근거까지 남아 있다.</li>
+    <li><strong>LLM 러너의 조회 배치화</strong> — 활성 종목 현재가/전일가를 각 1쿼리로. N+1(목록 1번 + 항목마다 1번씩 총 N+1번 조회하는 안티패턴) 없음.</li>
+    <li><strong>헛 호출 방지 설계의 일관성</strong> — 이어하기, 멱등 가드(같은 작업을 두 번 실행해도 결과가 한 번과 동일하도록 하는 장치), 7일 중복 방지, 사용량 한도 즉시 중단이 전 경로에 있다 (2편 §3과 일치).</li>
+    <li><strong>부분 인덱스가 핫 쿼리와 정확히 정합</strong> — 후보 선별 쿼리 조건과 인덱스 조건이 일치.</li>
+    <li><strong>pykrx 타임아웃 주입</strong> — 외부 API 무한 대기 사고의 재발 차단.</li>
+    <li><strong>freeze의 단일 빌드 재사용</strong> — LLM 입력과 감사 아티팩트를 한 번의 빌드로 만들어 이중 렌더가 없다.</li>
+  </ul>
+</section>
+
+<section id="priority" class="fade">
+  <h2><span class="no">7</span>우선순위 요약</h2>
+  <div class="rule"></div>
+  <div class="tbl-scroll"><table>
+    <thead><tr><th>순위</th><th>항목</th><th>절감</th><th>노력</th><th>상태</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>C4 DART 기간 일괄 조회</td><td>외부 호출 ~99%↓ (2,500→1~수 회/일)</td><td>—</td><td><strong>PR #13 머지</strong></td></tr>
+      <tr><td>2</td><td>D1 freeze 청소 스케줄 등록</td><td>스토리지 무한증가 정지</td><td>—</td><td><strong>PR #11 머지</strong> (+S3 skip 후속)</td></tr>
+      <tr><td>3</td><td>T1 테스트 baseline 0화</td><td>세션마다의 판독 toil 제거</td><td>—</td><td><strong>PR #12 머지</strong></td></tr>
+      <tr><td>4</td><td>C1 지수 로드 루프 밖으로</td><td>DB 왕복 2,550회 + 중복 74만 행/일</td><td>극소</td><td>신규</td></tr>
+      <tr><td>5</td><td>S1 휴장일 가드</td><td>연 ~12일치 전체 체인 (KRX 5,100호출/일 포함)</td><td>소</td><td>신규</td></tr>
+      <tr><td>6</td><td>C5 sanity 풀스캔 WHERE 한정</td><td>매일 130만 행 스캔 제거</td><td>극소</td><td>신규</td></tr>
+      <tr><td>7</td><td>C2 지표 쓰기 증폭 완화</td><td>행 버전 ~21만→~3만/일</td><td>중</td><td>안전마진 검토 필요</td></tr>
+      <tr><td>8</td><td>C3·C5(스윕 외 잔여 포함)·S2·S3·T2·D2</td><td>각각 소규모</td><td>소~중</td><td>여유 있을 때</td></tr>
+    </tbody>
+  </table></div>
+  <div class="callout teal">
+    <span class="label">시리즈 전체를 한 문장으로</span>
+    <p>이 시스템의 뼈대(스크리너, SSOT, 게이트, 검증 문화)는 견실하다. 남은 일은 <strong>LLM에게서 계산기 일을 회수하고(1편), 호출과 데이터를 다이어트하고(2편), 수동 동기화 구간의 모순을 닫고(3편), 전 종목 앞단의 반복 낭비를 걷어내는 것(4편)</strong> — 그리고 그 절반은 이미 오픈 PR로 문 앞에 와 있다.</p>
+  </div>
+</section>
+
+<footer>
+  <span>kr-by-claude 리뷰 시리즈 4/4 — 비효율 검토</span>
+  <span>이전: 03 모순 검토 · 시리즈 끝</span>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/artifacts/2026-07-08-llm-review-series/index.html
+++ b/docs/artifacts/2026-07-08-llm-review-series/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>kr-by-claude 리뷰 시리즈 — 2026-07-08 밤샘 감사 4편</title>
+<style>
+  :root {
+    --paper: #f7f3ea;
+    --paper-deep: #efe8d8;
+    --ink: #2b2620;
+    --ink-soft: #5c544a;
+    --accent: #8a3324;
+    --accent-soft: #f3e0da;
+    --teal: #1f5f5b;
+    --teal-soft: #dcebe9;
+    --gold: #a07d2a;
+    --gold-soft: #f2ead2;
+    --line: #d8cfbd;
+    --mono: "SF Mono", ui-monospace, Menlo, monospace;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: "Apple SD Gothic Neo", "Noto Sans KR", "Pretendard", sans-serif;
+    line-height: 1.75; font-size: 16.5px;
+    display: flex; flex-direction: column;
+  }
+
+  /* ── 상단 탭 바 ─────────────────────────────── */
+  .topbar {
+    flex: 0 0 auto;
+    background: var(--ink); color: var(--paper);
+    border-bottom: 3px solid var(--accent);
+    padding: 0 18px;
+    display: flex; align-items: stretch; gap: 4px;
+    overflow-x: auto; white-space: nowrap;
+  }
+  .topbar .brand {
+    font-family: "Nanum Myeongjo", serif; font-weight: 800; font-size: 15px;
+    display: flex; align-items: center; padding: 14px 16px 14px 4px;
+    letter-spacing: .02em; flex: 0 0 auto;
+  }
+  .topbar .brand small { font-family: var(--mono); font-weight: 400; font-size: 10.5px; opacity: .65; margin-left: 10px; letter-spacing: .1em; }
+  .tabs { display: flex; align-items: stretch; gap: 2px; margin-left: auto; }
+  .tab-btn {
+    appearance: none; border: none; background: transparent; color: var(--paper);
+    font-family: inherit; font-size: 13.5px; cursor: pointer;
+    padding: 0 16px; opacity: .65;
+    border-bottom: 3px solid transparent; margin-bottom: -3px;
+    transition: opacity .15s;
+  }
+  .tab-btn:hover { opacity: 1; }
+  .tab-btn.active { opacity: 1; border-bottom-color: var(--paper); font-weight: 700; }
+  .tab-btn .n { font-family: var(--mono); font-size: 10.5px; color: var(--gold-soft); margin-right: 6px; }
+
+  /* ── 패널 ───────────────────────────────────── */
+  .panel { flex: 1 1 auto; display: none; min-height: 0; }
+  .panel.active { display: block; }
+  .panel iframe { width: 100%; height: 100%; border: none; display: block; background: var(--paper); }
+  #panel-cover { overflow-y: auto; }
+
+  /* ── 표지 (에디토리얼) ──────────────────────── */
+  .wrap { max-width: 880px; margin: 0 auto; padding: 0 28px 100px; }
+  header.masthead { padding: 64px 0 36px; border-bottom: 3px double var(--ink); margin-bottom: 40px; }
+  .series-tag {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .18em; text-transform: uppercase;
+    color: var(--accent); display: inline-block; border: 1px solid var(--accent);
+    padding: 4px 12px; border-radius: 999px; margin-bottom: 22px;
+  }
+  h1 { font-family: "Nanum Myeongjo", serif; font-size: clamp(30px, 5vw, 46px); font-weight: 800; line-height: 1.3; margin-bottom: 18px; }
+  h1 em { font-style: normal; color: var(--accent); }
+  .dek { font-size: 18px; color: var(--ink-soft); max-width: 44em; }
+  .byline { margin-top: 20px; font-family: var(--mono); font-size: 12.5px; color: var(--ink-soft); }
+  section { margin-bottom: 60px; }
+  h2 { font-family: "Nanum Myeongjo", serif; font-size: 25px; font-weight: 800; margin-bottom: 6px; }
+  .rule { width: 64px; height: 3px; background: var(--accent); margin: 12px 0 22px; }
+  p { margin-bottom: 16px; max-width: 47em; }
+  ul, ol { margin: 0 0 18px 24px; }
+  li { margin-bottom: 9px; max-width: 45em; }
+  code { font-family: var(--mono); font-size: .85em; background: var(--paper-deep); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--line); }
+  .callout { margin: 24px 0; padding: 20px 24px; border-radius: 6px; background: var(--accent-soft); border-left: 4px solid var(--accent); }
+  .callout.teal { background: var(--teal-soft); border-left-color: var(--teal); }
+  .callout .label { font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase; display: block; margin-bottom: 8px; }
+  .callout p:last-child { margin-bottom: 0; }
+
+  .stat-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 14px; margin: 26px 0; }
+  .stat { background: #fffdf7; border: 1.5px solid var(--ink); border-radius: 10px; padding: 16px 18px; box-shadow: 4px 4px 0 rgba(43,38,32,.10); }
+  .stat .v { font-family: "Nanum Myeongjo", serif; font-size: 26px; font-weight: 800; color: var(--accent); line-height: 1.15; }
+  .stat .k { font-size: 12.5px; color: var(--ink-soft); margin-top: 6px; line-height: 1.5; }
+
+  .doc-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin: 26px 0; }
+  @media (max-width: 720px) { .doc-grid { grid-template-columns: 1fr; } }
+  .doc-card {
+    text-align: left; cursor: pointer; appearance: none; font-family: inherit; font-size: inherit; color: inherit;
+    background: #fffdf7; border: 1.5px solid var(--ink); border-radius: 10px;
+    padding: 20px 22px; box-shadow: 5px 5px 0 rgba(43,38,32,.10);
+    transition: transform .12s, box-shadow .12s;
+  }
+  .doc-card:hover { transform: translate(-2px,-2px); box-shadow: 7px 7px 0 rgba(43,38,32,.14); }
+  .doc-card .num { font-family: var(--mono); font-size: 11px; letter-spacing: .16em; color: var(--accent); display: block; margin-bottom: 8px; }
+  .doc-card h3 { font-family: "Nanum Myeongjo", serif; font-size: 18px; font-weight: 800; margin-bottom: 8px; line-height: 1.4; }
+  .doc-card p { font-size: 13.5px; color: var(--ink-soft); margin-bottom: 10px; line-height: 1.65; }
+  .doc-card .takeaway { font-size: 13px; color: var(--teal); font-weight: 700; }
+  .doc-card .takeaway::before { content: "핵심 한 줄 — "; color: var(--teal); }
+
+  .tbl-scroll { overflow-x: auto; margin: 22px 0; border: 1px solid var(--line); border-radius: 8px; background: #fffdf7; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; min-width: 560px; }
+  th { text-align: left; font-size: 12px; letter-spacing: .08em; padding: 12px 16px; background: var(--paper-deep); border-bottom: 2px solid var(--ink); white-space: nowrap; }
+  td { padding: 11px 16px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+
+  footer { margin-top: 80px; padding-top: 22px; border-top: 3px double var(--ink); font-family: var(--mono); font-size: 12px; color: var(--ink-soft); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+  .fade { animation: fadeUp .7s ease both; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(14px);} to { opacity: 1; transform: none;} }
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <div class="brand">kr-by-claude 리뷰 시리즈<small>2026-07-08</small></div>
+  <nav class="tabs" role="tablist">
+    <button class="tab-btn active" data-tab="cover" role="tab">표지</button>
+    <button class="tab-btn" data-tab="d1" role="tab"><span class="n">01</span>결정론 분리</button>
+    <button class="tab-btn" data-tab="d2" role="tab"><span class="n">02</span>효율화</button>
+    <button class="tab-btn" data-tab="d3" role="tab"><span class="n">03</span>모순 검토</button>
+    <button class="tab-btn" data-tab="d4" role="tab"><span class="n">04</span>비효율 검토</button>
+  </nav>
+</div>
+
+<!-- ── 표지 ─────────────────────────────────────── -->
+<div class="panel active" id="panel-cover" role="tabpanel">
+<div class="wrap">
+
+<header class="masthead fade">
+  <span class="series-tag">시스템 감사 리포트 · 4편 합본</span>
+  <h1>이 분석 체계는 <em>믿을 만한가,</em><br>그리고 <em>아낄 곳</em>은 어디인가</h1>
+  <p class="dek">주식 스크리너 + AI 차트 분석 파이프라인(kr-by-claude)을 하룻밤 동안 네 가지 관점에서 자동 점검한 결과물이다. 각 편은 초안 작성 후 실제 코드와 한 줄 한 줄 대조하는 검증 리뷰를 2라운드씩 통과했다. 위 탭에서 각 편을 열어볼 수 있고, 이 표지는 왜 이 점검을 했는지·무엇이 나왔는지를 요약한다.</p>
+  <p class="byline">2026-07-08 밤샘 자동 작업 · 코드 기준 origin/main · PR #15</p>
+</header>
+
+<section class="fade">
+  <h2>왜 이 점검을 했나 — 세 가지 질문</h2>
+  <div class="rule"></div>
+  <p>이 시스템은 "정해진 규칙대로 계산하는 <strong>코드</strong>"와 "차트를 보고 판단하는 <strong>AI(LLM)</strong>"가 역할을 나눠 맡는다. 코드는 공짜에 가깝고 같은 입력엔 언제나 같은 답을 주지만, AI는 호출마다 돈과 시간이 들고 가끔 계산을 틀리며 같은 질문에 다른 답을 줄 수도 있다. 시스템이 커지면서 자연스럽게 세 가지 질문이 쌓였다:</p>
+  <ul>
+    <li><strong>역할 분담이 맞나?</strong> — AI에게 시키는 일 중에 사실 계산기(코드)가 해도 되는 일이 섞여 있지 않은가. → <strong>01편</strong>이 답하고, 그 연장선에서 <strong>02편</strong>이 "AI를 쓰되 더 싸고 빠르게 쓰는 법"을 다룬다.</li>
+    <li><strong>규칙끼리 어긋난 곳은 없나?</strong> — 규칙이 세 곳(임계값 정의 파일, AI 지시문, 파이썬 코드)에 나뉘어 살고 그중 AI 지시문은 사람이 손으로 맞춰야 한다. → <strong>03편</strong>.</li>
+    <li><strong>매일 도는 파이프라인이 낭비 없이 도나?</strong> — 2,500여 종목 전체를 상대하는 앞단은 헛돈이 새기 쉽다. → <strong>04편</strong>.</li>
+  </ul>
+  <div class="callout">
+    <span class="label">작업 방식</span>
+    <p>각 편은 ① 코드베이스 전수 조사 → ② 초보자 눈높이로 초안 작성 → ③ 별도 검증자가 <strong>실제 코드 라인과 대조</strong>하며 오류·과장·용어 걸림돌을 지적 → ④ 반영 후 재검증, 을 지적이 사라질 때까지(각 2라운드) 반복해 만들었다. 이 과정에서 초안의 오류도 실제로 여럿 잡혔다 — 예: "ETF를 미리 거르면 절감된다"는 주장은 검증에서 기각됐다(이미 상류에서 걸러지고 있었다).</p>
+  </div>
+</section>
+
+<section class="fade">
+  <h2>각 편 안내 — 카드를 누르면 해당 탭이 열린다</h2>
+  <div class="rule"></div>
+  <div class="doc-grid">
+    <button class="doc-card" data-open="d1">
+      <span class="num">01 · DETERMINISTIC</span>
+      <h3>LLM이 하는 일 중, 계산기로 옮길 수 있는 것들</h3>
+      <p>AI를 쓰는 곳은 세 군데다: (A) 차트를 보고 종목 분류, (B) "오늘 사도 되나" 판정, (C) 매수가·손절가·비중 계산. 각각에서 "숫자와 규칙만으로 답이 정해지는 일"과 "차트 모양을 보는 눈이 필요한 일"을 가른다.</p>
+      <span class="takeaway">C는 지시문 자체가 계산 절차서라 통째로 코드화 가능, B는 정량 조건 선계산, A만 시각 판단으로서 AI가 필수.</span>
+    </button>
+    <button class="doc-card" data-open="d2">
+      <span class="num">02 · EFFICIENCY</span>
+      <h3>LLM을 더 싸고 더 빠르게 쓰는 방법</h3>
+      <p>호출 1건의 실측 비용 구조(총 ~10.7만 토큰, 130~224초)를 분해하고, 개선 카드 12장을 효과·위험·검증 방법과 함께 제시한다. 이미 끝난 최적화(토큰 −77~83%)와 남은 것을 구분한다.</p>
+      <span class="takeaway">느린 진짜 원인은 답변 길이가 아니라 AI의 내부 사고(thinking) — 진단 런 기준 종목당 234초 중 ~160초. 이 예산 조절이 미개척 최대 레버.</span>
+    </button>
+    <button class="doc-card" data-open="d3">
+      <span class="num">03 · CONTRADICTIONS</span>
+      <h3>분석 체계에 모순은 없는가</h3>
+      <p>스크리너·지시문·게이트·저장 코드를 라인 단위로 맞대본 적대적 감사. 확정 모순 8건 + 조건부 8건, 그리고 자동 감시 테스트가 못 보는 사각을 찾았다. 점검 후 무죄였던 15개 항목도 기록.</p>
+      <span class="takeaway">최위험 2건: 매수 파라미터 지시문이 전달되지 않는 입력을 참조(일부 규칙 작동 불능), "시장 나쁨" 강등이 사유 재확인 없이 매수 신호로 역류 가능.</span>
+    </button>
+    <button class="doc-card" data-open="d4">
+      <span class="num">04 · INEFFICIENCIES</span>
+      <h3>어디서 새고 있는가 — 비효율 검토</h3>
+      <p>LLM 밖의 낭비: 하루 ~7,600번의 외부 API 호출 대부분이 "변한 것 없음" 응답을 받으러 가고, 휴장일에도 전체 체인이 돌며, 청소 코드가 스케줄에 빠져 보관함이 무한 증가 중이었다.</p>
+      <span class="takeaway">상위 발견 3건은 이미 열린 PR #11·#12·#13이 고치는 중 — 최우선 액션은 새 작업이 아니라 그 PR들의 머지.</span>
+    </button>
+  </div>
+</section>
+
+<section class="fade">
+  <h2>전체 개괄 — 숫자로 보는 결과</h2>
+  <div class="rule"></div>
+  <div class="stat-row">
+    <div class="stat"><div class="v">3곳</div><div class="k">LLM 사용 지점 (분류 A · 타이밍 B · 파라미터 C) — 그중 1곳(C)은 통째 코드화 가능 판정</div></div>
+    <div class="stat"><div class="v">12장</div><div class="k">효율화 개선 카드 (권장 2 · 실험 필요 8 · 재검토 1 · 상식 1)</div></div>
+    <div class="stat"><div class="v">8 + 8건</div><div class="k">확정 모순 + 조건부 모순 (무죄 확인 15항목 별도 기록)</div></div>
+    <div class="stat"><div class="v">3건</div><div class="k">비효율 상위 발견 중 이미 오픈 PR로 수리 대기 중인 것 (#11 #12 #13)</div></div>
+  </div>
+  <p>네 편을 관통하는 결론은 하나로 모인다: <strong>이 시스템의 뼈대는 견실하다.</strong> 결정론 스크리너, 임계값 단일 출처(SSOT), 보수적 게이트, "의심되면 코드로 재검증"하는 문화는 감사에서 반복적으로 무죄가 확인됐다. 문제는 뼈대가 아니라 <strong>수동 동기화 구간</strong> — 사람이 손으로 맞추는 AI 지시문 안팎 — 에 몰려 있고, 이는 곧 01편의 처방(정량 규칙을 코드로 내리기)이 비용 문제인 동시에 품질 문제라는 뜻이다. 규칙이 코드로 내려오면 이런 부류의 어긋남은 테스트가 잡는다.</p>
+  <div class="tbl-scroll"><table>
+    <thead><tr><th>우선순위</th><th>할 일</th><th>출처</th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>오픈 PR 머지: #13(DART 호출 99%↓) · #11(보관함 청소 스케줄) · #12(테스트 기준선 0화) · #5(감시 테스트 확장)</td><td>04편 · 03편</td></tr>
+      <tr><td>2</td><td>모순 최위험 수리 — C 지시문의 유령 입력 정리, "시장 나쁨" 회복 게이트에 분배일 재확인 추가, 분배일 정의 통일(코드 0% 컷 → 책 기준 −0.2%)</td><td>03편</td></tr>
+      <tr><td>3</td><td>C(매수 파라미터)의 결정론 함수 대체 — 선행 결정 3건 확정 후 진행</td><td>01편</td></tr>
+      <tr><td>4</td><td>thinking 예산 실험 + 페이로드 중복 제거 실험 (판정 불변 검사 통과 조건)</td><td>02편</td></tr>
+      <tr><td>5</td><td>파이프라인 소규모 수리 — 지수 루프 재조회 제거, 휴장일 가드, sanity 스캔 범위 한정</td><td>04편</td></tr>
+    </tbody>
+  </table></div>
+  <div class="callout teal">
+    <span class="label">읽는 순서</span>
+    <p>01 → 02 → 03 → 04 순서로 쓰였지만, 각 편 서두에 필요한 용어(pivot, payload, 분배일 등)를 다시 정의해 두어 아무 편이나 먼저 읽어도 된다. 문서 속 제안은 제안일 뿐 아직 실행되지 않았다 — 특히 임계값을 건드리는 수리는 프로젝트 규칙(의존성 맵 작성)이 선행돼야 한다.</p>
+  </div>
+</section>
+
+<footer>
+  <span>kr-by-claude 리뷰 시리즈 · 4편 합본 표지</span>
+  <span>원본: docs/artifacts/2026-07-08-llm-review-series/ · PR #15</span>
+</footer>
+
+</div>
+</div>
+
+<!-- ── 본문 4편 (iframe, 첫 진입 시 로드) ───────── -->
+<div class="panel" id="panel-d1" role="tabpanel"><iframe data-src="01-deterministic-extraction.html" title="01 결정론 분리"></iframe></div>
+<div class="panel" id="panel-d2" role="tabpanel"><iframe data-src="02-llm-efficiency.html" title="02 효율화"></iframe></div>
+<div class="panel" id="panel-d3" role="tabpanel"><iframe data-src="03-contradictions.html" title="03 모순 검토"></iframe></div>
+<div class="panel" id="panel-d4" role="tabpanel"><iframe data-src="04-inefficiencies.html" title="04 비효율 검토"></iframe></div>
+
+<script>
+(function () {
+  var buttons = document.querySelectorAll('.tab-btn');
+  function activate(key) {
+    buttons.forEach(function (b) {
+      var on = b.dataset.tab === key;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    document.querySelectorAll('.panel').forEach(function (p) {
+      p.classList.toggle('active', p.id === 'panel-' + key);
+    });
+    var panel = document.getElementById('panel-' + key);
+    var frame = panel && panel.querySelector('iframe[data-src]');
+    if (frame && !frame.src) frame.src = frame.dataset.src; // 첫 진입 시에만 로드
+    // 표지를 처음 열 때는 URL을 건드리지 않는다 (#cover 오염 방지)
+    if (history.replaceState && (key !== 'cover' || location.hash)) {
+      history.replaceState(null, '', '#' + key);
+    }
+  }
+  buttons.forEach(function (b) {
+    b.addEventListener('click', function () { activate(b.dataset.tab); });
+  });
+  document.querySelectorAll('.doc-card[data-open]').forEach(function (c) {
+    c.addEventListener('click', function () { activate(c.dataset.open); });
+  });
+  function fromHash() {
+    var key = location.hash ? location.hash.slice(1) : 'cover';
+    if (!document.getElementById('panel-' + key)) key = 'cover';
+    activate(key);
+  }
+  window.addEventListener('hashchange', fromHash);
+  fromHash();
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## 개요

이 시스템(주식 스크리너 + AI 차트 분석 파이프라인)을 네 가지 관점에서 밤새 자동으로 점검하고, 그 결과를 **초보자도 읽을 수 있는 HTML 리포트 4편**으로 정리했습니다. 코드 변경은 없고 문서만 추가하는 PR입니다.

## 배경 — 왜 이 점검을 했나

이 프로젝트는 "정해진 규칙대로 계산하는 코드"와 "차트를 보고 판단하는 AI(LLM)"가 역할을 나눠 맡고 있습니다. 그런데 시스템이 커지면서 자연스럽게 세 가지 질문이 쌓였습니다.

1. **AI에게 시키는 일 중에, 사실 계산기(코드)가 해도 되는 일이 섞여 있지 않나?** — AI는 호출할 때마다 돈과 시간이 들고, 가끔 계산을 틀리고, 같은 질문에 다른 답을 줄 수 있습니다. 반면 코드는 공짜에 가깝고 절대 흔들리지 않습니다.
2. **규칙이 세 곳(임계값 파일, AI 지시문, 파이썬 코드)에 나뉘어 사는데, 서로 어긋난 곳은 없나?** — 특히 AI 지시문은 사람이 손으로 맞춰줘야 해서 어긋날 기회가 많습니다.
3. **매일 도는 파이프라인이 낭비 없이 돌고 있나?** — 2,500여 종목 전체를 상대하는 앞단에서 헛돈이 새기 쉽습니다.

이 질문들에 답하기 위해, 조사 → 초보자 눈높이로 정리 → **실제 코드와 한 줄 한 줄 대조하는 검증 리뷰를 2라운드씩** 돌리는 방식으로 4편을 만들었습니다. 리뷰 과정에서 초안의 오류(예: "ETF를 미리 거르면 절감된다"는 주장 — 실제로는 이미 걸러지고 있었음)도 여러 건 잡아서 고쳤습니다.

## 변경 내용 — 각 리포트가 담은 것

`docs/artifacts/2026-07-08-llm-review-series/` 에 HTML 4편 + 합본 표지(`index.html`) 추가. **index.html 하나만 열면** 표지(작업 목적·전체 개괄·우선순위 표)와 4편을 탭으로 오가며 읽을 수 있습니다:

- **01 · LLM에서 계산기 일 분리하기** — AI를 쓰는 곳은 세 군데입니다: (A) 차트 보고 종목 분류, (B) "오늘 사도 되나" 판정, (C) 매수가·손절가·비중 계산. 점검 결과 **C는 지시문 자체가 계산 절차서**라 통째로 코드로 바꿀 수 있고, B는 숫자 조건을 코드가 미리 계산해줄 수 있으며, A만 "차트 모양을 보는 눈"으로서 AI가 꼭 필요합니다.
- **02 · AI를 더 싸고 빠르게** — 개선 카드 12장. 가장 큰 발견: 응답이 느린 진짜 원인은 답변 길이가 아니라 **AI가 답하기 전에 하는 내부 사고(thinking)** 였습니다(종목당 234초 중 ~160초). 그 외 중복 데이터 제거, 평일 경로 병렬화 등을 효과·위험과 함께 정리.
- **03 · 규칙끼리 모순은 없나** — **확정 모순 8건 + 조건부 8건** 발견. 가장 위험한 두 가지: ① 매수 파라미터 지시문이 **실제로는 전달되지 않는 입력 필드**를 참조해서 일부 규칙이 통째로 작동 불능 상태, ② "시장 여건 나쁨"으로 강등된 종목이 **그 여건이 그대로인데도** 나중에 정상 매수 신호를 받을 수 있는 구멍. 반대로 점검했지만 멀쩡했던 15개 항목도 함께 기록해서, 다음 점검이 같은 곳을 다시 파지 않게 했습니다.
- **04 · 어디서 새고 있나** — 하루 ~7,600번의 외부 API 호출 대부분이 "변한 것 없음" 응답을 받으러 가고, 청소 코드는 완성돼 있는데 실행 스케줄에 빠져 있어 보관함이 무한 증가 중이었습니다. 반가운 점: **상위 발견 3건은 이미 열려 있는 PR(#11, #12, #13)이 고치는 중**이라, 최우선 액션은 새 작업이 아니라 그 PR들의 머지입니다.

## 읽는 법

- 각 파일을 브라우저로 열면 됩니다(외부 의존성 없는 단일 HTML). 01부터 순서대로 읽도록 썼지만, 각 편 서두에 필요한 용어를 다시 정의해서 아무 편이나 먼저 읽어도 됩니다.
- 문서 속 제안(모순 수리, 결정론화 등)은 **제안일 뿐 이 PR이 실행하지 않습니다.** 특히 임계값 관련 수리는 프로젝트 규칙대로 의존성 맵 작성이 선행돼야 합니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

