### PR TITLE
fix(prompts): 5b abort 카탈로그 자기참조 오류 §3.3 → §3.4

### DIFF
--- a/prompts/evaluate_pivot_trigger_v1.md
+++ b/prompts/evaluate_pivot_trigger_v1.md
@@ -158,13 +158,13 @@ Strict JSON only. No commentary, no markdown:
 - `decision`: "go_now" | "wait" | "abort"
 - `confidence`: 0.0~1.0
 - `reasoning`: ≤200자 한국어
-- `abort_reason`: abort 시 §3.3 카탈로그 키워드, 그 외 null
+- `abort_reason`: abort 시 §3.4 카탈로그 키워드, 그 외 null
 
 ## 5. Constraints
 
 - abort 는 신중히. 단일 약세일은 wait 으로 (베이스 여전히 valid 가능).
 - pivot/base/pattern 재산출 금지.
-- 새 키워드 만들지 말 것 (§3.3 카탈로그 외).
+- 새 키워드 만들지 말 것 (§3.4 카탈로그 외).
 - reasoning ≤200자 한국어.
 - Use ONLY the provided input payload. Do NOT use web search, external lookups, news, or earnings calendars — no information beyond the provided inputs, and no future information.
 


### PR DESCRIPTION
## 무엇

`prompts/evaluate_pivot_trigger_v1.md` 의 abort_reason 키워드 카탈로그 참조 두 곳을 정정한다 — §4 Output Schema(:161)와 §5 Constraints(:167)가 카탈로그를 **§3.3**(promotion 절)으로 잘못 가리키고 있었고, 실제 카탈로그는 **§3.4**다. :143 은 원래부터 올바르게 §3.4 를 참조.

Fixes #16

## 왜

프롬프트 내부 자기참조 오류. LLM 이 §3.3 을 카탈로그로 오독할 이론적 여지가 있으나 §3.4 절 제목이 명확해 실질 오동작 가능성은 낮음 — 문서 정합성 수정.

## 범위/검증

- 참조 텍스트 치환 2곳뿐, 임계값·판정 룰 변경 없음 (threshold-change-checklist 비대상)
- `uv run pytest tests/test_prompt_threshold_drift.py` → **2 passed** (worktree 에 .env 가 없으면 skip 되므로 TEST_DATABASE_URL 로드 후 실행)
- 발견 경위: 파이프라인 해설서(PR #14) 작성 중 프롬프트 원문 대조 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)