### PR TITLE
climax 이관 후속 — 최종 리뷰 triage 4건(문언·주석·엣지 테스트)

### DIFF
--- a/kr_pipeline/common/thresholds.py
+++ b/kr_pipeline/common/thresholds.py
@@ -382,7 +382,8 @@ CLIMAX_GAIN_WINDOW_WEEKS: Final[int] = 3
 """[PRESERVES] climax 상승률 측정 창 상한(주). HMMS p.262-263 '1-2 weeks', TTLC '1-3 weeks'."""
 
 CLIMAX_UP_DAYS_PCT: Final[float] = 70.0
-"""[PRESERVES] climax T4 트리거: 윈도우 내 상승일 비율 임계. TTLC Ch.9 / HMMS p.263 (#4)."""
+"""[PRESERVES] climax T4 트리거: 윈도우 내 상승일 비율 임계. 공식(70%·7~15일) 출처는
+TTLC Ch.9 — HMMS p.263 (#4) 는 '7 of 8 or 8 of 10' 로 별도 서술(2026-07-21 외부 자문 정정)."""
 CLIMAX_UP_DAYS_WINDOW_MIN: Final[int] = 7
 CLIMAX_UP_DAYS_WINDOW_MAX: Final[int] = 15
 """[PRESERVES] T4 상승일 측정 윈도우 (거래일 7~15). TTLC Ch.9."""

--- a/kr_pipeline/llm_runner/compute/climax_topping.py
+++ b/kr_pipeline/llm_runner/compute/climax_topping.py
@@ -297,6 +297,9 @@ def compute_topping_gates(weekly: list[dict], dist_count_25s: int | None, anchor
         start_idx = 0 if anchor["no_transition"] else last_idx - anchor["weeks_since"]
         declines: dict[int, float] = {}
         down_vols: dict[int, float] = {}
+        # anchor 주(i=start_idx) 자체도 후보에 포함하되 하락 판정은 anchor "이전" 주
+        # 대비다 — §6.1 baseline 이 anchor 주를 포함하는 관례(P2/T1/T2)와 일관 정렬.
+        # anchor 주는 정의상 상승 확정 주라 실발화는 사실상 없음(Task 4 리뷰 확정 해석).
         for i in range(max(start_idx, 1), n):
             prev = closes[i - 1]
             if prev is None or prev <= 0 or closes[i] >= prev:

--- a/prompts/analyze_chart_v3.md
+++ b/prompts/analyze_chart_v3.md
@@ -380,7 +380,9 @@ current week, **anchor week itself included** — not "the week after the anchor
   불가능한 진짜 결측): §6.1 의 모든 필드가 `null`(`maturity_ok`·`p2_*`·`t1_max_spread_now`·
   `t2_max_volume_now`·`scope_active`·`quality_flag_climax` 포함) — climax_run 을 발화하지
   말 것(전제 판정 불능 = 미충족과 동일 취급). §6.2 의 anchor 비의존 게이트(아래 참조)는
-  이 모드에서도 정상 계산된다.
+  이 모드에서도 정상 계산된다. 예외: `supporting_ext_sma200_pct` 는 anchor 와 무관한
+  일봉 지표(SMA-200 이격)라 이 모드에서도 값이 공급될 수 있다 — supporting 은 어차피
+  단독 불충분 신호이므로 참고만 하고, null 인 §6.1 게이트의 대체 근거로 쓰지 말 것.
 - `no_transition=True` (이력은 충분하나(>50주) 전 이력에 Stage 1→2 전환 조건을 만족하는
   주가 전무 — 예: 줄곧 Stage 2 상승): `anchor_week=null` 이지만 게이트 거부가 아니다. P1
   은 충족 간주로 이미 공급됨(`maturity_ok=True`), P2/T1/T2/scope 극값은 anchor 없이 **전체

--- a/tests/test_climax_topping.py
+++ b/tests/test_climax_topping.py
@@ -171,3 +171,39 @@ def test_topping_dist_none_conservative():
     g = compute_topping_gates(wk, dist_count_25s=None, anchor=anchor)
     assert g["td_dist_ok"] is None
     assert g["g0_below_10w"] is False  # dist 결측과 무관하게 계산됨(독립성)
+
+
+# ---- triage 회귀 고정 (PR #56 최종 리뷰 이월 — scope 엣지 2본) ----
+
+
+def test_scope_high_tie_uses_most_recent_occurrence():
+    """고점 동률 시 '가장 최근 발생' 기준으로 경과를 세는 확정 해석의 회귀 고정.
+
+    최고 종가 1800 이 idx85·idx87 두 번 등장 — 최근(idx87) 기준 경과 1주(≤2)라
+    scope_active=True 여야 한다. 이전 발생(idx85) 기준이면 경과 3주로 False 가 되므로
+    이 픽스처는 두 해석을 판별한다(Task 3 리뷰 확정 해석의 테스트 공백 보강).
+    """
+    rows = _drift(65, 1000.0, 980.0) + [(1100.0, 260_000)] \
+        + [(1100.0 + 35 * i, 110_000) for i in range(1, 21)] \
+        + [(1750.0, 100_000), (1800.0, 100_000), (1790.0, 100_000)]
+    wk = _mk_weeks(rows)
+    anchor = find_anchor(wk)
+    assert anchor["anchor_week"] == wk[65]["week_end"]
+    g = compute_climax_gates(wk, _mk_daily_updays(10, up=5), anchor)
+    assert g["scope_active"] is True  # 최근 고점(1주 전) 기준 — 동률 최근 채택
+
+
+def test_climax_gates_anchor_at_last_week_conservative():
+    """anchor 가 마지막 주(weeks_since=0)인 극단에서 보수 폴백 회귀 고정.
+
+    성숙(maturity_ok)은 False 로 확정되고, P2 는 True 로 새지 않는다 —
+    best_ever 부재 극단이 발화 전제를 만들지 못함(최종 리뷰 이월 항목).
+    """
+    rows = _drift(65, 1000.0, 980.0) + [(1100.0, 260_000)]
+    wk = _mk_weeks(rows)
+    anchor = find_anchor(wk)
+    assert anchor["weeks_since"] == 0
+    g = compute_climax_gates(wk, _mk_daily_updays(10, up=5), anchor)
+    assert g["maturity_ok"] is False
+    assert g["p2_accel_ok"] is not True
+    assert g["p2_is_steepest"] is not True


### PR DESCRIPTION
## 개요
PR #56(§6.1/§6.2 이관) 최종 whole-branch 리뷰가 비차단으로 이월한 triage 4건의 일괄 반영 — 동작 변경 없음(문언 1·주석 2·회귀 테스트 2본).

## 변경 내용
- 프롬프트 left_censored 절에 `supporting_ext_sma200_pct` 예외 명시(값 공급 가능·단독 불충분·null 게이트 대체 근거 금지)
- thresholds T4 주석 출처 정정 — 공식(70%·7~15일)=TTLC Ch.9, HMMS p.263(#4)는 별도 서술(2026-07-21 외부 자문)
- `compute_topping_gates` T-A/T-D 의 anchor 주 판정 기준 주석(동작 무변경)
- scope 엣지 회귀 테스트 2본: 고점 동률 시 최근 발생 채택(판별 픽스처 — 리뷰어 손계산 검증), anchor 마지막 주 보수 폴백

## 검증
- focused 14/14, full suite **1006 passed / 0 failed**(동시 pytest 부재 확인 후 실행)
- 독립 리뷰 Approved — 프로덕션 로직 변경이 주석뿐임을 diff 로 확정, 픽스처 판별력 손계산 재현

## 관련 이슈
Connects to #44 후속 정리(최종 리뷰 triage). 관측 계열 후속은 #59·#60.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
