### PR TITLE
fix(store): 백필 insert 경로에 분류 가격 sanity 적용 (#50)

### DIFF
--- a/kr_pipeline/db/schema.sql
+++ b/kr_pipeline/db/schema.sql
@@ -511,6 +511,10 @@ ALTER TABLE classification_backfill
 ALTER TABLE classification_backfill
   ADD COLUMN IF NOT EXISTS verdict_original TEXT;
 
+-- (#50) sanity_warnings — weekly_classification 과 동일 의미 (SOFT 경고, 쓰기 전용)
+ALTER TABLE classification_backfill
+  ADD COLUMN IF NOT EXISTS sanity_warnings JSONB;
+
 -- ====== 수익성·강건성 백테스트 전용 분류 테이블 (2026-06-23) ======
 -- classification_backfill 스키마 복제. pre-lockdown 적재분과 격리해 "검색-차단 클린
 -- 환경" 을 구조적으로 보장(spec §5.0). 적재·멱등 resume 모두 이 테이블 기준.
@@ -547,6 +551,10 @@ CREATE INDEX IF NOT EXISTS idx_backtest_classification_date
 -- (#44 Task 7) verdict_original — weekly_classification 과 동일 의미
 ALTER TABLE backtest_classification
   ADD COLUMN IF NOT EXISTS verdict_original TEXT;
+
+-- (#50) sanity_warnings — weekly_classification 과 동일 의미 (SOFT 경고, 쓰기 전용)
+ALTER TABLE backtest_classification
+  ADD COLUMN IF NOT EXISTS sanity_warnings JSONB;
 
 -- ====== Phase 0 Step 4: FREEZE 최소판 (#P0-S4) ======
 -- 분류 (weekend/daily_delta) 시점의 분석 입력 ZIP 을 사후 검증 가능하도록 보존.
@@ -612,3 +620,7 @@ CREATE INDEX IF NOT EXISTS idx_recall_audit_classification_date
 -- (#44 Task 7) verdict_original — weekly_classification 과 동일 의미
 ALTER TABLE recall_audit_classification
   ADD COLUMN IF NOT EXISTS verdict_original TEXT;
+
+-- (#50) sanity_warnings — weekly_classification 과 동일 의미 (SOFT 경고, 쓰기 전용)
+ALTER TABLE recall_audit_classification
+  ADD COLUMN IF NOT EXISTS sanity_warnings JSONB;

--- a/kr_pipeline/llm_runner/store.py
+++ b/kr_pipeline/llm_runner/store.py
@@ -457,7 +457,8 @@ def insert_backfill_classification(
 ) -> None:
     """백필 분류 결과를 `table` (기본 classification_backfill) 에 INSERT (멱등: symbol+analyzed_for_date).
 
-    insert_classification 과 동일하게 Phase 1 2-A 후처리 게이트 적용. freeze 는 만들지 않음.
+    insert_classification 과 동일하게 Phase 1 2-A 후처리 게이트 + (#50) 가격 sanity
+    적용 (HARD=저장 거부, SOFT=sanity_warnings). freeze 는 만들지 않음.
     table 파라미터로 대상 테이블 지정 가능 (allowlist: classification_backfill,
     backtest_classification, recall_audit_classification).
     """
@@ -481,6 +482,15 @@ def insert_backfill_classification(
         result = _original
         triggered_rules = None
 
+    # (#50) weekly(insert_classification)와 동일한 게이트 뒤 가격 sanity — HARD 위반은
+    # ValueError 로 저장 거부(fail-closed), 호출자 워커(run_parallel_batch)가 단건 격리.
+    # as_of=analyzed_for_date (이슈 명세). 주의: 게이트는 gate_at(=D+1) 종가를 보므로
+    # 평일 셀(recall_audit)에선 sanity 와 종가 원천이 하루 어긋날 수 있음 — 토요일 셀은
+    # 동일 최종거래일로 수렴. SOFT 전용이라 판정 무영향.
+    sanity_warnings = _validate_classification_prices(
+        conn, result, symbol=symbol, as_of=analyzed_for_date,
+    )
+
     with conn.cursor() as cur:
         cur.execute(
             f"""
@@ -493,12 +503,14 @@ def insert_backfill_classification(
                triggered_rules,
                measurements,
                watch_reason,
-               verdict_original)
+               verdict_original,
+               sanity_warnings)
             VALUES (%s, %s, %s, %s, %s, %s,
                     %s, %s, %s, %s, %s, %s,
                     %s, %s, %s,
                     %s,
                     %s, %s, %s, %s,
+                    %s,
                     %s,
                     %s,
                     %s,
@@ -530,6 +542,7 @@ def insert_backfill_classification(
                 _measurements_json(result),
                 _watch_reason(result),
                 verdict_original,
+                json.dumps(sanity_warnings) if sanity_warnings else None,
             ),
         )
 

--- a/tests/test_backfill_price_sanity.py
+++ b/tests/test_backfill_price_sanity.py
@@ -1,0 +1,141 @@
+# tests/test_backfill_price_sanity.py
+# (#50) 백필 insert 경로 가격 sanity — weekly(insert_classification)와 동일하게
+# HARD 위반은 저장 거부(fail-closed), SOFT 는 sanity_warnings 컬럼에 기록.
+from datetime import datetime, date, timezone
+
+import pytest
+
+BACKFILL_TABLES = (
+    "classification_backfill",
+    "backtest_classification",
+    "recall_audit_classification",
+)
+
+
+def _cls_result(**over):
+    """유효한 분류 result 기본형 (HARD 통과값) — test_llm_runner_store 와 동형."""
+    r = {
+        "classification": "watch", "pattern": "flat_base", "confidence": 0.6,
+        "reasoning": "t", "risk_flags": [], "pivot_price": 1000.0,
+        "pivot_basis": "high_of_base", "base_high": 1000.0, "base_low": 900.0,
+        "base_depth_pct": 10.0, "base_start_date": None,
+    }
+    r.update(over)
+    return r
+
+
+def _gates_identity(mocker):
+    """게이트를 identity 로 patch — sanity 로직만 단위 테스트."""
+    mocker.patch(
+        "kr_pipeline.llm_runner.store.apply_phase1_gates",
+        side_effect=lambda conn, s, t, r: (r, None),
+    )
+
+
+def _insert(db, *, symbol, result, table):
+    from kr_pipeline.llm_runner.store import insert_backfill_classification
+    insert_backfill_classification(
+        db, symbol=symbol, classified_at=datetime(2026, 7, 21, 1, tzinfo=timezone.utc),
+        market="KOSPI", result=result, source="backfill",
+        llm_meta={"duration_s": 1.0}, analyzed_for_date=date(2022, 4, 9), table=table,
+    )
+
+
+@pytest.mark.parametrize("table", BACKFILL_TABLES)
+def test_backfill_sanity_warnings_column_exists(db, table):
+    """(#50) 백필 3테이블 모두 sanity_warnings JSONB 컬럼 존재."""
+    with db.cursor() as cur:
+        cur.execute(
+            """
+            SELECT data_type FROM information_schema.columns
+             WHERE table_name = %s AND column_name = 'sanity_warnings'
+            """,
+            (table,),
+        )
+        row = cur.fetchone()
+    assert row is not None, f"{table}.sanity_warnings 컬럼 없음 — schema.sql ALTER 미적용"
+    assert row[0] == "jsonb"
+
+
+def test_backfill_hard_rejects_impossible_prices(db, mocker):
+    """HARD: 구조적으로 불가능한 가격은 ValueError + 행 미생성 (fail-closed).
+
+    weekly 와 동일 기준 — 오염 pivot 은 백테스트 지표·트리거 재생의 상류 입력이라
+    저장 자체를 거부한다. 워커(run_parallel_batch)가 단건 실패로 격리.
+    """
+    _gates_identity(mocker)
+    cases = [
+        {"pivot_price": -100.0},
+        {"base_low": 1000.0, "base_high": 900.0},   # low >= high
+        {"base_low": 950.0, "pivot_price": 900.0},  # low > pivot
+        {"confidence": 1.5},
+    ]
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM classification_backfill WHERE symbol='BFH'")
+    db.commit()
+
+    for over in cases:
+        with pytest.raises(ValueError, match="sanity"):
+            _insert(db, symbol="BFH", result=_cls_result(**over),
+                    table="classification_backfill")
+        db.rollback()
+
+    with db.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM classification_backfill WHERE symbol='BFH'")
+        assert cur.fetchone()[0] == 0, "HARD 위반 백필 분류가 저장됨 (fail-closed 깨짐)"
+
+
+@pytest.mark.parametrize("table", BACKFILL_TABLES)
+def test_backfill_soft_entry_without_pivot_warns(db, mocker, table):
+    """SOFT: pivot 없는 entry 는 저장은 되되 sanity_warnings 에 기록 (#50 재현 케이스).
+
+    실증: 표본 B 317870@2022-04-09 — entry + base_high 있는데 pivot_price NULL 이
+    무검사 저장돼 §8.5 extended 게이트·트리거가 영원히 skip 되는 행동 불능 행.
+    3테이블 공통 — insert 는 단일 경로지만 컬럼 누락은 테이블별로 깨질 수 있다.
+    """
+    _gates_identity(mocker)
+    with db.cursor() as cur:
+        cur.execute(f"DELETE FROM {table} WHERE symbol='BFS'")
+    db.commit()
+
+    _insert(
+        db, symbol="BFS",
+        result=_cls_result(classification="entry", pivot_price=None),
+        table=table,
+    )
+    db.commit()
+    try:
+        with db.cursor() as cur:
+            cur.execute(f"SELECT sanity_warnings FROM {table} WHERE symbol='BFS'")
+            row = cur.fetchone()
+        assert row is not None, "SOFT 경고 케이스가 저장되지 않음 (SOFT 는 저장 유지)"
+        assert row[0] is not None and "sanity_missing_pivot_for_actionable" in row[0]
+    finally:
+        with db.cursor() as cur:
+            cur.execute(f"DELETE FROM {table} WHERE symbol='BFS'")
+        db.commit()
+
+
+def test_backfill_clean_result_saved_without_warnings(db, mocker):
+    """정상값: 저장되고 sanity_warnings 는 NULL (기본 테이블 경로)."""
+    _gates_identity(mocker)
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM classification_backfill WHERE symbol='BFOK'")
+    db.commit()
+
+    _insert(db, symbol="BFOK", result=_cls_result(), table="classification_backfill")
+    db.commit()
+    try:
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT classification, sanity_warnings FROM classification_backfill "
+                "WHERE symbol='BFOK'"
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "watch"
+        assert row[1] is None
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM classification_backfill WHERE symbol='BFOK'")
+        db.commit()


### PR DESCRIPTION
Closes #50

## 무엇을
`insert_backfill_classification` 이 enum 검사만 하고 가격 sanity(`_validate_classification_prices`)를 건너뛰어, pivot 없는 entry(표본 B 317870@2022-04-09 실증)가 무검사 저장되던 공백을 weekly 경로와 동일 규약으로 닫는다.

## 변경
- **kr_pipeline/llm_runner/store.py** — 게이트 뒤(최종 저장값)에 `_validate_classification_prices` 호출, `as_of=analyzed_for_date`(이슈 명세). HARD 위반은 ValueError 저장 거부(fail-closed), SOFT 는 신설 `sanity_warnings` 컬럼에 기록. 단건 격리는 기존 `run_parallel_batch` 워커의 예외 흡수로 충족 — 세 백필 러너(backfill·backtest·recall_audit) 전부 이 경로만 사용(리뷰에서 전 repo grep 확인). `ValueError` 는 `_TRANSIENT_EXC` 밖이라 **재시도 없이 즉시 단건 실패** — 추가 LLM 호출 없음.
- **kr_pipeline/db/schema.sql** — 백필 3테이블(`classification_backfill`·`backtest_classification`·`recall_audit_classification`)에 `ADD COLUMN IF NOT EXISTS sanity_warnings JSONB` (weekly 와 동일 의미, 쓰기 전용).
- **tests/test_backfill_price_sanity.py** — TDD(RED 6건 확인 후 GREEN): 컬럼 존재 3건 + HARD 거부·행 미생성 + SOFT 기록(3테이블 파라미터화) + 정상값 NULL.

## 검증
- 전체 스위트 **1037 passed / 0 failed** (base 1031 + 신규 6·파라미터화로 8). 중간 1회 8건 실패는 kr_test 교차 세션 경합의 가짜 실패로 판별(단독 통과 + 재실행 clean).
- 독립 코드리뷰 1기: Critical/Important(코드) 0건, "Ready to merge: Yes". minor 2건(주석·테스트 파라미터화) 반영.
- 기존 오염 행(317870 1건)은 이슈 명세대로 수정 범위 아님 — 백필 재실행 시 자연 교정.

## ⚠ 머지 체크리스트 (schema 수동 적용 관례)
INSERT 가 `sanity_warnings` 를 무조건 참조하므로, **다음 백필 실행 전에** 양쪽 DB에 적용 필요 — 미적용 시 LLM 호출 비용을 쓴 뒤 UndefinedColumn 으로 배치 전건 실패:
```
psql -d kr_pipeline -f kr_pipeline/db/schema.sql
psql -d kr_test -f kr_pipeline/db/schema.sql   # (pytest conftest 는 자동 재적용)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)