### PR TITLE
feat(ohlcv): 수정 봉 불변식 위반 관측 경고 — 취급 방침 (a)+(c) (#49)

### DIFF
--- a/kr_pipeline/ohlcv/modes.py
+++ b/kr_pipeline/ohlcv/modes.py
@@ -91,6 +91,19 @@ def _empty_fetch_warning(empties: list[str], total: int) -> list[str]:
     return [msg]
 
 
+# (#49) 수정 OHLC 봉 불변식 위반의 실측 기준 (2026-07-17 0단계 검증 F1, 21,541행).
+# 소스(pykrx adjusted)가 수정 환산 시 컬럼별 독립 반올림을 해 adj_close > adj_high
+# 행을 돌려주는 것을 직접 호출로 확증 — 로컬 수리 불가라 보정은 보류(관측 전용).
+# 강조 신호 2종 (empty_fetch 임계와 동일 철학 — 항상 집계, 임계 초과 시 강조):
+# 1) 절대 기준 초과 — full-refresh 가 과거 이력까지 대량 오염시키는 소스 변화 감지.
+#    단, 카운트는 주간 재정규화로 하향 드리프트(2026-07-21 실측 21,288)하므로
+#    이 기준의 민감도는 ±수백 행 수준이다 — 소량 신규 위반은 2)가 담당.
+# 2) 최근 30일 위반 행 수 — 신규 적재분의 위반 급증 감지 (드리프트 무관).
+#    2025+ 전체가 8행(월 ~0.7행)이라 30일 3행 초과는 정상 대비 ~4배 신호.
+_ADJ_INVARIANT_BASELINE = 21_541
+_ADJ_INVARIANT_RECENT_WARN = 3
+
+
 def _run_sanity_checks(conn: Connection, mode: Mode) -> list[str]:
     """OHLCV 적재 후 데이터 sanity 검증. 경고 메시지 리스트 반환 (실패 아님).
 
@@ -98,6 +111,9 @@ def _run_sanity_checks(conn: Connection, mode: Mode) -> list[str]:
     1. 최근 영업일 커버리지: daily_prices 의 가장 최근 날짜에 들어온 종목 수가
        활성 universe 의 80% 미만이면 경고.
     2. 가격 이상치: close <= 0 또는 adj_close <= 0 인 행이 있으면 경고.
+    3. (#49) 수정 봉 불변식: adj_close 가 adj_high 초과 또는 adj_low 미만인 행
+       카운트 — pykrx 유래 관측 전용. 강조는 최근 30일 급증(우선) 또는
+       절대 기준(_ADJ_INVARIANT_BASELINE) 초과 시.
 
     full-refresh 모드는 새 행을 추가하지 않으므로 커버리지 검증을 건너뜀.
     """
@@ -132,6 +148,36 @@ def _run_sanity_checks(conn: Connection, mode: Mode) -> list[str]:
         bad_price_count = cur.fetchone()[0] or 0
         if bad_price_count > 0:
             warnings.append(f"bad_prices: {bad_price_count} 행이 close 또는 adj_close <= 0")
+
+        # 검증 3 (#49): 수정 봉 불변식 (adj_low ≤ adj_close ≤ adj_high)
+        # total 은 COUNT(*)(고유 행) — 양방향 동시 위반 행의 이중 계수 방지.
+        cur.execute("""
+            SELECT COUNT(*),
+                   COUNT(*) FILTER (WHERE adj_close > adj_high),
+                   COUNT(*) FILTER (WHERE adj_close < adj_low),
+                   COUNT(*) FILTER (WHERE date >= CURRENT_DATE - 30),
+                   MAX(date)
+              FROM daily_prices
+             WHERE adj_close > adj_high OR adj_close < adj_low
+        """)
+        total, over_high, under_low, recent, latest = cur.fetchone()
+        if total > 0:
+            msg = (
+                f"adj_ohlc_invariant: {total}행 수정 봉 불변식 위반 "
+                f"(close>high {over_high}·close<low {under_low}, 최근 {latest}) "
+                f"— pykrx 반올림 유래 관측(#49)"
+            )
+            if recent > _ADJ_INVARIANT_RECENT_WARN:
+                msg += (
+                    f" — 최근 30일 {recent}행(임계 {_ADJ_INVARIANT_RECENT_WARN}행 초과), "
+                    f"신규 적재 위반 급증 — 소스 동작 변화 의심"
+                )
+            elif total > _ADJ_INVARIANT_BASELINE:
+                msg += (
+                    f" — 기준 {_ADJ_INVARIANT_BASELINE:,}행(2026-07 실측) 초과, "
+                    f"소스 동작 변화 의심"
+                )
+            warnings.append(msg)
 
     return warnings
 

--- a/tests/test_ohlcv_modes.py
+++ b/tests/test_ohlcv_modes.py
@@ -280,3 +280,138 @@ def test_full_refresh_accounts_empty_fetches(monkeypatch, db):
     )
     joined = " ".join(stats.warnings)
     assert "empty_fetch" in joined and "2/2" in joined and "EMFR1" in joined
+
+
+# ====== (#49) 수정 OHLC 봉 불변식 관측 (pykrx adjusted 반올림 유래, 관측 전용) ======
+
+def _insert_price_row(cur, ticker, d, *, adj_close, adj_high, adj_low):
+    cur.execute(
+        "INSERT INTO stocks (ticker, name, market) VALUES (%s, %s, 'KOSPI') ON CONFLICT DO NOTHING",
+        (ticker, ticker),
+    )
+    cur.execute(
+        """
+        INSERT INTO daily_prices (ticker, date, open, high, low, close, volume, value,
+                                  adj_close, adj_high, adj_low)
+        VALUES (%s, %s, 10000, 10450, 9900, 10450, 1000, 1000, %s, %s, %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (ticker, d, adj_close, adj_high, adj_low),
+    )
+
+
+def test_sanity_checks_adj_invariant_warning(db):
+    """adj_close > adj_high 또는 adj_close < adj_low 행이 있으면 관측 경고 1건."""
+    from kr_pipeline.ohlcv.modes import _run_sanity_checks, Mode
+    from datetime import date as _date
+
+    with db.cursor() as cur:
+        # 재현 실측(#49): 299900@2021-03-22 고가 2612 < 종가 2613 (환산계수 0.25 반올림)
+        _insert_price_row(cur, "INV1", _date(2021, 3, 22),
+                          adj_close=2613, adj_high=2612, adj_low=2551)
+        _insert_price_row(cur, "INV2", _date(2021, 3, 23),
+                          adj_close=2500, adj_high=2612, adj_low=2551)  # close < low
+    db.commit()
+
+    try:
+        warnings = _run_sanity_checks(db, Mode.FULL_REFRESH)
+        inv = [w for w in warnings if w.startswith("adj_ohlc_invariant")]
+        assert len(inv) == 1, f"관측 경고 1건이어야 함: {warnings}"
+        assert "close>high 1" in inv[0] and "close<low 1" in inv[0]
+        assert "2021-03-23" in inv[0]  # 최근 위반일
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_prices WHERE ticker IN ('INV1','INV2')")
+            cur.execute("DELETE FROM stocks WHERE ticker IN ('INV1','INV2')")
+        db.commit()
+
+
+def test_sanity_checks_no_adj_invariant_warning_when_clean(db):
+    """불변식 위반 0행이면 경고 없음."""
+    from kr_pipeline.ohlcv.modes import _run_sanity_checks, Mode
+    from datetime import date as _date
+
+    with db.cursor() as cur:
+        _insert_price_row(cur, "INVOK", _date(2021, 3, 22),
+                          adj_close=2612, adj_high=2612, adj_low=2551)
+    db.commit()
+
+    try:
+        warnings = _run_sanity_checks(db, Mode.FULL_REFRESH)
+        assert not any(w.startswith("adj_ohlc_invariant") for w in warnings)
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_prices WHERE ticker = 'INVOK'")
+            cur.execute("DELETE FROM stocks WHERE ticker = 'INVOK'")
+        db.commit()
+
+
+def test_sanity_checks_adj_invariant_baseline_emphasis(db, monkeypatch):
+    """실측 기준(baseline) 초과 시에만 강조 문구 — 소스 동작 변화 신호."""
+    from kr_pipeline.ohlcv import modes
+    from datetime import date as _date
+
+    with db.cursor() as cur:
+        _insert_price_row(cur, "INVB", _date(2021, 3, 22),
+                          adj_close=2613, adj_high=2612, adj_low=2551)
+    db.commit()
+
+    try:
+        monkeypatch.setattr(modes, "_ADJ_INVARIANT_BASELINE", 0)
+        over = [w for w in modes._run_sanity_checks(db, modes.Mode.FULL_REFRESH)
+                if w.startswith("adj_ohlc_invariant")]
+        assert len(over) == 1 and "기준" in over[0] and "초과" in over[0]
+
+        monkeypatch.setattr(modes, "_ADJ_INVARIANT_BASELINE", 21_541)
+        under = [w for w in modes._run_sanity_checks(db, modes.Mode.FULL_REFRESH)
+                 if w.startswith("adj_ohlc_invariant")]
+        assert len(under) == 1 and "초과" not in under[0]
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_prices WHERE ticker = 'INVB'")
+            cur.execute("DELETE FROM stocks WHERE ticker = 'INVB'")
+        db.commit()
+
+
+def test_sanity_checks_adj_invariant_recent_emphasis(db, monkeypatch):
+    """최근 30일 위반이 임계 초과면 강조 — 절대 기준의 드리프트 사각을 보완.
+
+    절대 기준(21,541)은 주간 재정규화로 카운트가 하향 드리프트해 여유가 계속
+    늘어나므로, 신규 적재 위반은 최근 윈도우로 별도 감지한다 (리뷰 지적).
+    """
+    from kr_pipeline.ohlcv import modes
+    from datetime import date as _date, timedelta
+
+    recent_d = _date.today() - timedelta(days=5)
+    old_d = _date(2021, 3, 22)
+
+    with db.cursor() as cur:
+        _insert_price_row(cur, "INVR", recent_d,
+                          adj_close=2613, adj_high=2612, adj_low=2551)
+    db.commit()
+    try:
+        monkeypatch.setattr(modes, "_ADJ_INVARIANT_RECENT_WARN", 0)
+        w = [x for x in modes._run_sanity_checks(db, modes.Mode.FULL_REFRESH)
+             if x.startswith("adj_ohlc_invariant")]
+        assert len(w) == 1 and "최근 30일" in w[0] and "소스 동작 변화" in w[0]
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_prices WHERE ticker = 'INVR'")
+            cur.execute("DELETE FROM stocks WHERE ticker = 'INVR'")
+        db.commit()
+
+    # 같은 위반이라도 오래된 날짜면 recent 강조 없음
+    with db.cursor() as cur:
+        _insert_price_row(cur, "INVR2", old_d,
+                          adj_close=2613, adj_high=2612, adj_low=2551)
+    db.commit()
+    try:
+        monkeypatch.setattr(modes, "_ADJ_INVARIANT_RECENT_WARN", 0)
+        w = [x for x in modes._run_sanity_checks(db, modes.Mode.FULL_REFRESH)
+             if x.startswith("adj_ohlc_invariant")]
+        assert len(w) == 1 and "최근 30일" not in w[0]
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM daily_prices WHERE ticker = 'INVR2'")
+            cur.execute("DELETE FROM stocks WHERE ticker = 'INVR2'")
+        db.commit()


### PR DESCRIPTION
Closes #49

## 방침 결정
이슈의 3안 중 권장안 **(a) 적재 시 관측 + (c) 보정 보류** 채택. 원인이 pykrx adjusted의 컬럼별 독립 반올림(소스 유래·직접 호출로 확증)이라 로컬 수리가 근본 해결이 아니고, 2025+ 영향이 8행·≤10원으로 미미해 값 보정(클램프)은 하지 않는다. 데이터 변경 0 — 경고 문자열 하나가 전부.

## 변경
- **kr_pipeline/ohlcv/modes.py** — `_run_sanity_checks` 검증 3 신설: `adj_close > adj_high` / `adj_close < adj_low` 행을 단일 쿼리로 집계해 `adj_ohlc_invariant:` 경고로 승격(P1-5 empty_fetch 철학 — 항상 집계, 임계 초과 시 강조). 강조 신호 2단:
  1. **최근 30일 위반 > 3행** (우선) — 신규 적재분 급증 감지. 절대 카운트가 주간 재정규화로 하향 드리프트(21,541→21,288)해 절대 기준만으로는 현실적 회귀를 못 잡는다는 독립 리뷰 지적 반영
  2. 절대 기준 21,541행(2026-07-17 실측) 초과 — full-refresh가 과거 이력까지 대량 오염시키는 소스 변화 감지
- **tests/test_ohlcv_modes.py** — TDD 4건: 경고 발화(양방향 카운트+최근 위반일, 이슈 재현값 299900@2021-03-22 사용)·클린 시 무경고·절대 기준 강조·최근 윈도우 강조

## 검증
- 전체 스위트 **1051 passed / 0 failed**
- production 실측: 21,284+4행, 최근 위반일 2025-08-27, 쿼리 1.9s(일일 실행 허용) — 현재 상태에선 강조 없이 관측 경고만 뜨는 정확한 동작
- 독립 코드리뷰 1기: Critical 0. Important 1건(절대 기준의 드리프트 사각)·Minor(이중 계수) 반영. NULL 처리(halt 행 adj_* NULL → 비교에서 자동 탈락)·경고 소비처(runs.error JSON, 실패 취급 소비처 없음) 리뷰에서 확증
- halt 행·close_range_pos(증상 F1) 등 소비처는 비접촉 — 이 PR은 관측만 추가

## 참고
- 스키마 변경 없음 — psql 적용 불필요
- adj_open 범위 검사는 의도적 비포함(이슈 실측이 close 위반 기준)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
