### PR TITLE
feat(trade): 포지션 wiring — 수동 기록 + 일일 손절 평가 러너 (#47, 밤 2)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.deps import init_pool, close_pool
-from api.routers import stocks, indicators, heatmap, render, prompts, runs, market_context, signals, performance, runner, pipelines, classifications, triggers, index
+from api.routers import stocks, indicators, heatmap, render, prompts, runs, market_context, signals, performance, runner, pipelines, classifications, triggers, index, positions
 from api.routers import cron as cron_router
 
 
@@ -43,6 +43,7 @@ app.include_router(pipelines.router)
 app.include_router(classifications.router)
 app.include_router(triggers.router)
 app.include_router(index.router)
+app.include_router(positions.router)
 
 
 @app.get("/api/health")

--- a/api/routers/positions.py
+++ b/api/routers/positions.py
@@ -1,0 +1,86 @@
+"""(#47) 보유 포지션 + 일일 손절 평가 조회 API (read-only)."""
+from fastapi import APIRouter, Depends, Query
+from psycopg import Connection
+
+from api.deps import get_conn
+
+router = APIRouter(prefix="/api/positions", tags=["positions"])
+
+
+def _f(v):
+    return float(v) if v is not None else None
+
+
+@router.get("")
+def list_positions(
+    status: str = "open",
+    conn: Connection = Depends(get_conn),
+):
+    """포지션 목록 + 각자의 최신 손절 평가 1건 (LATERAL)."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT p.id, p.symbol, s.name, p.entry_date, p.entry_price, p.quantity,
+                   p.breakeven_armed, p.status, p.closed_at, p.close_reason, p.note,
+                   e.eval_date, e.close, e.sma_50, e.effective_stop, e.binding,
+                   e.triggered, e.warnings
+              FROM positions p
+              LEFT JOIN stocks s ON s.ticker = p.symbol
+              LEFT JOIN LATERAL (
+                SELECT eval_date, close, sma_50, effective_stop, binding,
+                       triggered, warnings
+                  FROM position_stop_evaluations
+                 WHERE position_id = p.id
+                 ORDER BY eval_date DESC
+                 LIMIT 1
+              ) e ON true
+             WHERE (%s = 'all' OR p.status = %s)
+             ORDER BY p.status DESC, p.entry_date DESC, p.id DESC
+            """,
+            (status, status),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "id": r[0], "symbol": r[1], "name": r[2], "entry_date": r[3],
+            "entry_price": _f(r[4]), "quantity": r[5],
+            "breakeven_armed": bool(r[6]), "status": r[7],
+            "closed_at": r[8], "close_reason": r[9], "note": r[10],
+            "last_eval": None if r[11] is None else {
+                "eval_date": r[11], "close": _f(r[12]), "sma_50": _f(r[13]),
+                "effective_stop": _f(r[14]), "binding": r[15],
+                "triggered": bool(r[16]), "warnings": r[17] or [],
+            },
+        }
+        for r in rows
+    ]
+
+
+@router.get("/{position_id}/evaluations")
+def list_evaluations(
+    position_id: int,
+    limit: int = Query(60, ge=1, le=500),
+    conn: Connection = Depends(get_conn),
+):
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT eval_date, close, sma_50, effective_stop, binding,
+                   breakeven_armed, triggered, warnings
+              FROM position_stop_evaluations
+             WHERE position_id = %s
+             ORDER BY eval_date DESC
+             LIMIT %s
+            """,
+            (position_id, limit),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "eval_date": r[0], "close": _f(r[1]), "sma_50": _f(r[2]),
+            "effective_stop": _f(r[3]), "binding": r[4],
+            "breakeven_armed": bool(r[5]), "triggered": bool(r[6]),
+            "warnings": r[7] or [],
+        }
+        for r in rows
+    ]

--- a/docs/superpowers/specs/2026-07-22-issue47-position-wiring.md
+++ b/docs/superpowers/specs/2026-07-22-issue47-position-wiring.md
@@ -1,0 +1,52 @@
+# #47 포지션 wiring 사전등록 — 수동 기록 + 일일 손절 평가 러너 (2026-07-22)
+
+> 스펙 §5(2026-07-13-manage-active-trade.md)가 예약한 wiring 의 이행 사전등록.
+> 선행 결정(2026-07-22, 사용자): **포지션 소스 = 수동 기록** — 어댑터 구조
+> (source 컬럼)로 브로커 연동 교체 가능하게 설계.
+
+## 1. 범위
+
+- `positions` / `position_stop_evaluations` 테이블 (schema.sql — psql 양쪽 수동 적용 관례)
+- 수동 기록 store(open/close/list) + CLI(`python -m kr_pipeline.trade_management`)
+- 일일 평가 러너 `run_daily_eval`: open 포지션마다 `evaluate_stop` 호출 →
+  평가 로그 기록(멱등: position_id+eval_date) → 래치 영속화 → 매도 신호 Slack
+  (`notify_stop_triggered`) — 신규 insert 시에만(중복 알림 방지)
+- 조회: API `/api/positions`(+`/{id}/evaluations`) + 웹 `/positions` 페이지
+- cron(머지 후 수동 반영 제안): 평일 19:10 — 일봉 체인(18:30, 최근 최대 26분) 종료 후
+  `10 19 * * 1-5  cd <repo> && uv run python -m kr_pipeline.trade_management --mode=daily-eval >> $HOME/.kr-by-claude/cron.log 2>&1`
+
+## 2. §3 불변 계약 승계 체크리스트 (준거: 2026-07-13 스펙)
+
+- [x] anchor = `positions.entry_price`(매수 시점 고정) — 러너는 분류 테이블
+  (weekly_classification 의 pivot/base_low)을 **조회조차 하지 않음** (구조적 차단,
+  회귀 테스트 `test_daily_eval_anchor_is_entry_price_not_classification`)
+- [x] `load.py get_active_with_current` 의 `stop_loss=base_low` 정의 재사용 금지 —
+  러너는 load.py 미사용
+- [x] 래치(breakeven_armed) 영속·단조 True(해제 없음) — positions 컬럼에 운반
+- [x] halt 센티널(close≤0)·봉 부재 skip — stop_stack ValueError 규약을 러너가 사전 이행
+- [x] 재분류·abort 와 독립 — 분류 상태가 손절 상태를 리셋하지 않음
+- [x] 단순 abort 모델 정합 — 전량 매도 신호만(quantity 는 기록용, 판정 무영향)
+
+## 3. 신규 규약 (본 wiring 이 추가)
+
+- **as_of 기본값 = daily_prices 최신 날짜** — cron 이 일봉 체인 뒤에 실행되는 규약과
+  결합해 "오늘 적재된 봉"을 평가. 명시 `--as-of` 재실행은 **기존 평가 행이 있는
+  날짜만** 안전(ON CONFLICT 멱등) — **미평가 과거일의 신규 평가는 러너가
+  `backdated_as_of` 로 거부**(리뷰 반영): 현재 래치의 과거 소급(시대착오)과
+  기업행위 후 스케일 불일치를 차단. Slack 알림에는 eval_date 를 명시해 과거일
+  알림의 실시간 오독 방지.
+- **close 원천 = daily_prices.close(raw)**: 당일 봉의 raw == 당일 adj(수정주가는
+  현재 앵커)라 sma_50(adj 기반)과 스케일 일관.
+- **수동 기록 모델의 한계와 보강**: 보유 중 기업행위(분할·증자) 발생 시
+  entry_price 만 과거 스케일로 남는다 — 러너가 corporate_actions 를 조회해
+  `corp_action_after_entry` 경고를 평가 로그에 기록(entry_price 수동 재조정 안내).
+  자동 조정은 브로커 연동 어댑터 도입 시 재검토.
+- 매도 신호는 **알림·표시까지만** — 주문 집행 없음(수동 매매). 신호 후 처리
+  (close_position 기록)는 사용자 CLI.
+
+## 4. 검증 계획
+
+- 단위: tests/test_trade_positions.py 9건(래치 영속·트리거·halt/결측 skip·멱등·
+  중복 알림 방지·corp-action 경고·anchor 절연·as_of 기본값) + API 2건 — TDD(RED 선행).
+- 실전 확인(머지·cron 반영 후): 첫 포지션 등록 → 다음 거래일 평가 로그 1행·
+  runs 성공 확인. go_now 발생 전이라도 러너는 빈 포지션에서 무해(no-op).

--- a/kr_pipeline/db/schema.sql
+++ b/kr_pipeline/db/schema.sql
@@ -631,3 +631,50 @@ ALTER TABLE recall_audit_classification
 -- (#50) sanity_warnings — weekly_classification 과 동일 의미 (SOFT 경고, 쓰기 전용)
 ALTER TABLE recall_audit_classification
   ADD COLUMN IF NOT EXISTS sanity_warnings JSONB;
+
+-- ====== (#47) 포지션 관리 wiring — 수동 기록 + 일일 손절 평가 (2026-07-22) ======
+-- 포지션 소스 결정(2026-07-22, 사용자): 수동 기록. source 컬럼은 어댑터 구조 —
+-- 브로커 연동 도입 시 'manual' 외 값으로 확장(스키마·러너는 소스와 독립).
+-- 스펙 §3 불변 계약: entry_price(평균매입가)는 매수 시점 고정 — 재분류 pivot/base_low
+-- 유입 금지. 단순 abort 모델 정합(전량 매도 신호만, 부분 청산·피라미딩 없음).
+CREATE TABLE IF NOT EXISTS positions (
+  id               BIGSERIAL PRIMARY KEY,
+  symbol           VARCHAR(10) NOT NULL,
+  entry_date       DATE NOT NULL,
+  entry_price      NUMERIC(12, 4) NOT NULL CHECK (entry_price > 0),
+  quantity         INTEGER,                        -- 선택 — 판정 무영향(전량 모델)
+  breakeven_armed  BOOLEAN NOT NULL DEFAULT FALSE, -- 2층 래치 (러너가 갱신·영속, 해제 없음)
+  status           VARCHAR(10) NOT NULL DEFAULT 'open',   -- open | closed
+  source           VARCHAR(20) NOT NULL DEFAULT 'manual',
+  closed_at        DATE,
+  close_reason     TEXT,
+  note             TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT positions_status_chk CHECK (status IN ('open', 'closed')),
+  CONSTRAINT positions_quantity_chk CHECK (quantity IS NULL OR quantity > 0)
+);
+CREATE INDEX IF NOT EXISTS idx_positions_open ON positions (status, symbol);
+-- 종목당 open 포지션 1개 (전량 매도 신호 모델 — 이중 등록 시 이중 평가·이중 알림 방지)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_positions_open_symbol
+  ON positions (symbol) WHERE status = 'open';
+
+-- 일일 손절 평가 로그 — 멱등 (position_id, eval_date). warnings: no_bar/halt 는
+-- 행 미생성(skip)이고, 여기 남는 것은 평가는 수행하되 주의가 필요한 경우
+-- (예: corp_action_after_entry — entry_price 수동 재확인).
+CREATE TABLE IF NOT EXISTS position_stop_evaluations (
+  -- FK 는 의도적으로 ON DELETE 없음 — 평가 이력은 보존 대상(포지션 삭제 경로 자체가
+  -- 없음, close 만 존재). 수동 DELETE 시 FK 에러가 나는 것이 정상.
+  position_id      BIGINT NOT NULL REFERENCES positions(id),
+  eval_date        DATE NOT NULL,
+  close            NUMERIC(12, 4) NOT NULL,
+  sma_50           NUMERIC(12, 4),
+  effective_stop   NUMERIC(12, 4) NOT NULL,
+  binding          VARCHAR(20) NOT NULL,
+  breakeven_armed  BOOLEAN NOT NULL,
+  triggered        BOOLEAN NOT NULL,
+  warnings         JSONB,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (position_id, eval_date)
+);
+CREATE INDEX IF NOT EXISTS idx_position_stop_eval_date
+  ON position_stop_evaluations (eval_date);

--- a/kr_pipeline/llm_runner/slack.py
+++ b/kr_pipeline/llm_runner/slack.py
@@ -32,6 +32,21 @@ def notify_signal(*, symbol: str, name: str, entry_price: float, stop_loss: floa
     _post({"text": text})
 
 
+def notify_stop_triggered(*, symbol: str, name: str, close: float,
+                          effective_stop: float, binding: str,
+                          eval_date=None) -> None:
+    """(#47) 보유 포지션 매도 신호 알림 (일일 손절 평가 러너).
+
+    eval_date 명시 — 과거일 재평가 알림이 실시간 신호로 오독되는 것 방지(리뷰).
+    """
+    when = f" [{eval_date}]" if eval_date else ""
+    text = (
+        f"🔴 *매도 신호*{when} `{symbol}` {name}\n"
+        f"종가 ₩{close:,.0f} < 유효 손절선 ₩{effective_stop:,.0f} ({binding})"
+    )
+    _post({"text": text})
+
+
 def notify_weekend_digest(*, entry_count: int, watch_count: int, ignore_count: int) -> None:
     """주말 (5) batch 다이제스트."""
     text = (

--- a/kr_pipeline/trade_management/__main__.py
+++ b/kr_pipeline/trade_management/__main__.py
@@ -1,0 +1,88 @@
+# kr_pipeline/trade_management/__main__.py
+"""(#47) 포지션 관리 진입점 — 수동 기록 CLI + 일일 손절 평가 러너.
+
+사용 예:
+  python -m kr_pipeline.trade_management --mode=daily-eval [--as-of 2026-07-22]
+  python -m kr_pipeline.trade_management --add 005930 --price 71000 [--date ...] [--qty 10]
+  python -m kr_pipeline.trade_management --close-id 3 [--reason "target hit"]
+  python -m kr_pipeline.trade_management --list
+"""
+import argparse
+import json
+import logging
+import sys
+from datetime import date
+
+from kr_pipeline.common.config import Config
+from kr_pipeline.common.logging import setup_logging
+from kr_pipeline.db.connection import connect
+from kr_pipeline.db.runs import run_tracking
+from kr_pipeline.trade_management.runner import run_daily_eval
+from kr_pipeline.trade_management.store import (
+    close_position, get_open_positions, open_position,
+)
+
+log = logging.getLogger("kr_pipeline.trade_management")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="python -m kr_pipeline.trade_management")
+    p.add_argument("--mode", choices=["daily-eval"], help="러너 모드")
+    p.add_argument("--as-of", type=date.fromisoformat, default=None)
+    p.add_argument("--add", metavar="SYMBOL", help="포지션 수동 개설")
+    p.add_argument("--price", type=float, help="--add 평균매입가")
+    p.add_argument("--date", dest="entry_date", type=date.fromisoformat,
+                   default=None, help="--add 매수일 (기본 오늘)")
+    p.add_argument("--qty", type=int, default=None)
+    p.add_argument("--note", default=None)
+    p.add_argument("--close-id", type=int, help="포지션 종료 (id)")
+    p.add_argument("--reason", default=None, help="--close-id 사유")
+    p.add_argument("--list", action="store_true", help="open 포지션 목록")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cfg = Config.load()
+    setup_logging(cfg.log_level)
+
+    with connect(cfg.database_url) as conn:
+        if args.mode == "daily-eval":
+            with run_tracking(conn, pipeline="trade_management", mode="daily-eval",
+                              params={"as_of": str(args.as_of) if args.as_of else None}) as state:
+                r = run_daily_eval(conn, as_of=args.as_of)
+                state["rows_affected"] = r["evaluated"]
+                if r["skipped"]:
+                    state["warnings"].append(
+                        f"skipped {len(r['skipped'])}: "
+                        + ", ".join(f"{s['symbol']}({s['reason']})" for s in r["skipped"])
+                    )
+                log.info("daily-eval %s: evaluated=%d triggered=%d skipped=%d",
+                         r["as_of"], r["evaluated"], r["triggered"], len(r["skipped"]))
+        elif args.add:
+            if not args.price:
+                log.error("--add 는 --price 필수")
+                return 1
+            pid = open_position(
+                conn, symbol=args.add, entry_date=args.entry_date or date.today(),
+                entry_price=args.price, quantity=args.qty, note=args.note,
+            )
+            log.info("opened position id=%d %s @ %s", pid, args.add, args.price)
+        elif args.close_id:
+            try:
+                close_position(conn, position_id=args.close_id, reason=args.reason)
+            except ValueError as e:
+                log.error("%s", e)
+                return 1
+            log.info("closed position id=%d", args.close_id)
+        elif args.list:
+            print(json.dumps(get_open_positions(conn), default=str,
+                             ensure_ascii=False, indent=2))
+        else:
+            log.error("동작 지정 필요: --mode=daily-eval | --add | --close-id | --list")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kr_pipeline/trade_management/runner.py
+++ b/kr_pipeline/trade_management/runner.py
@@ -1,0 +1,157 @@
+"""(#47) 일일 손절 평가 러너 — open 포지션마다 evaluate_stop 호출·기록·알림.
+
+스펙 §3 불변 계약 준수:
+- anchor = positions.entry_price (매수 시점 고정) — 분류 테이블의 pivot/base_low
+  를 조회조차 하지 않는다(구조적 유입 차단, D4 체크리스트).
+- 래치(breakeven_armed)는 positions 에 영속 — 해제 없음(단조 True).
+- halt 센티널(close<=0)·봉 부재는 평가 skip (stop_stack 규약 — 러너가 거름).
+- 재분류·abort 상태와 독립 — 분류 테이블 미참조.
+
+close 원천 = daily_prices.close (raw): 당일 봉의 raw == 당일 adj (수정주가는 현재
+앵커)라 sma_50(adj 기반)과 스케일 일관. 보유 중 기업행위 발생 시 entry_price 만
+과거 스케일로 남는 한계는 corp_action_after_entry 경고로 노출(수동 기록 모델 —
+사용자가 entry_price 재조정).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date
+
+from psycopg import Connection
+
+from kr_pipeline.llm_runner.slack import notify_stop_triggered
+from kr_pipeline.trade_management.stop_stack import evaluate_stop
+from kr_pipeline.trade_management.store import get_open_positions
+
+log = logging.getLogger("kr_pipeline.trade_management")
+
+
+def _latest_bar_date(conn: Connection) -> date | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT MAX(date) FROM daily_prices")
+        row = cur.fetchone()
+    return row[0] if row else None
+
+
+def run_daily_eval(conn: Connection, *, as_of: date | None = None) -> dict:
+    """open 포지션 전체를 as_of 종가로 평가. 멱등: (position_id, eval_date).
+
+    as_of 미지정 → daily_prices 최신 날짜(일봉 체인 완료 후 cron 실행 규약).
+    반환: {"as_of", "evaluated", "triggered", "skipped": [{symbol, reason}]}.
+    """
+    if as_of is None:
+        as_of = _latest_bar_date(conn)
+        if as_of is None:
+            return {"as_of": None, "evaluated": 0, "triggered": 0, "skipped": []}
+
+    evaluated = 0
+    triggered = 0
+    skipped: list[dict] = []
+
+    for p in get_open_positions(conn):
+        # (리뷰) backdated 재실행 차단 — 이미 더 나중 날짜가 평가된 포지션에 과거
+        # as_of 를 새로 평가하면 현재 래치가 과거에 소급 적용(시대착오)되고, 과거
+        # raw close 와 현재 앵커 sma_50 의 스케일 불일치 위험도 있다. 기존 행이
+        # 있는 날짜의 재실행은 ON CONFLICT 멱등으로 무해 — 신규 과거일만 거부.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT MAX(eval_date) FROM position_stop_evaluations "
+                "WHERE position_id = %s",
+                (p["id"],),
+            )
+            last_eval = cur.fetchone()[0]
+        if last_eval is not None and as_of < last_eval:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM position_stop_evaluations "
+                    "WHERE position_id = %s AND eval_date = %s",
+                    (p["id"], as_of),
+                )
+                exists = cur.fetchone() is not None
+            if not exists:
+                skipped.append({"symbol": p["symbol"], "reason": "backdated_as_of"})
+                continue
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT close FROM daily_prices WHERE ticker = %s AND date = %s",
+                (p["symbol"], as_of),
+            )
+            bar = cur.fetchone()
+        if bar is None:
+            skipped.append({"symbol": p["symbol"], "reason": "no_bar"})
+            continue
+        close = float(bar[0]) if bar[0] is not None else 0.0
+        if close <= 0:
+            skipped.append({"symbol": p["symbol"], "reason": "halt_bar"})
+            continue
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT sma_50 FROM daily_indicators WHERE ticker = %s AND date = %s",
+                (p["symbol"], as_of),
+            )
+            row = cur.fetchone()
+        sma_50 = float(row[0]) if row and row[0] is not None else None
+
+        warnings: list[str] = []
+        with conn.cursor() as cur:
+            # 경계 >= : 매수 당일 발효 기업행위도 경고 대상 (리뷰 — 보수 방향)
+            cur.execute(
+                "SELECT COUNT(*) FROM corporate_actions "
+                "WHERE ticker = %s AND event_date >= %s AND event_date <= %s",
+                (p["symbol"], p["entry_date"], as_of),
+            )
+            ca = cur.fetchone()[0] or 0
+        if ca:
+            warnings.append(
+                f"corp_action_after_entry:{ca} — entry_price 수동 재확인 필요"
+                "(수동 기록 모델 한계)"
+            )
+
+        d = evaluate_stop(
+            entry_price=p["entry_price"], close=close, sma_50=sma_50,
+            breakeven_armed=p["breakeven_armed"],
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO position_stop_evaluations
+                  (position_id, eval_date, close, sma_50, effective_stop, binding,
+                   breakeven_armed, triggered, warnings)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (position_id, eval_date) DO NOTHING
+                """,
+                (p["id"], as_of, close, sma_50, d.effective_stop, d.binding,
+                 d.breakeven_armed, d.triggered,
+                 json.dumps(warnings) if warnings else None),
+            )
+            inserted = cur.rowcount == 1
+            # 래치 영속화 — 단조 True (해제 없음, 스펙 §2②)
+            if d.breakeven_armed and not p["breakeven_armed"]:
+                cur.execute(
+                    "UPDATE positions SET breakeven_armed = TRUE WHERE id = %s",
+                    (p["id"],),
+                )
+        evaluated += 1
+        if d.triggered:
+            triggered += 1
+            if inserted:  # 멱등 재실행의 중복 알림 방지
+                with conn.cursor() as cur:
+                    cur.execute("SELECT name FROM stocks WHERE ticker = %s",
+                                (p["symbol"],))
+                    nrow = cur.fetchone()
+                notify_stop_triggered(
+                    symbol=p["symbol"], name=nrow[0] if nrow else p["symbol"],
+                    close=close, effective_stop=d.effective_stop, binding=d.binding,
+                    eval_date=as_of,
+                )
+                log.warning(
+                    "[stop-triggered] %s close %.0f < stop %.0f (%s)",
+                    p["symbol"], close, d.effective_stop, d.binding,
+                )
+
+    return {"as_of": as_of, "evaluated": evaluated, "triggered": triggered,
+            "skipped": skipped}

--- a/kr_pipeline/trade_management/store.py
+++ b/kr_pipeline/trade_management/store.py
@@ -1,0 +1,73 @@
+"""(#47) positions 수동 기록 store — open/close/조회.
+
+포지션 소스 결정(2026-07-22): 수동 기록. 어댑터 구조 — 브로커 연동 도입 시
+이 모듈 뒤에 소스 어댑터를 붙이고 source 컬럼으로 구분(러너·스키마는 불변).
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from psycopg import Connection
+
+
+def open_position(
+    conn: Connection,
+    *,
+    symbol: str,
+    entry_date: date,
+    entry_price: float,
+    quantity: int | None = None,
+    note: str | None = None,
+    source: str = "manual",
+) -> int:
+    """포지션 개설 — 새 id 반환. entry_price 는 평균매입가(체결 사실, 이후 불변)."""
+    if entry_price is None or not (entry_price > 0):
+        raise ValueError(f"entry_price must be positive: {entry_price}")
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO positions (symbol, entry_date, entry_price, quantity, note, source)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (symbol, entry_date, entry_price, quantity, note, source),
+        )
+        return cur.fetchone()[0]
+
+
+def close_position(conn: Connection, *, position_id: int, reason: str | None = None,
+                   closed_at: date | None = None) -> None:
+    """포지션 종료 — 이후 일일 평가 대상에서 제외. 평가 이력은 보존."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE positions
+               SET status = 'closed', closed_at = COALESCE(%s, CURRENT_DATE),
+                   close_reason = %s
+             WHERE id = %s AND status = 'open'
+            """,
+            (closed_at, reason, position_id),
+        )
+        if cur.rowcount != 1:
+            raise ValueError(f"open position not found: id={position_id}")
+
+
+def get_open_positions(conn: Connection) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, symbol, entry_date, entry_price, quantity, breakeven_armed, note
+              FROM positions
+             WHERE status = 'open'
+             ORDER BY entry_date, id
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "id": r[0], "symbol": r[1], "entry_date": r[2],
+            "entry_price": float(r[3]), "quantity": r[4],
+            "breakeven_armed": bool(r[5]), "note": r[6],
+        }
+        for r in rows
+    ]

--- a/tests/test_api_positions.py
+++ b/tests/test_api_positions.py
@@ -1,0 +1,63 @@
+# tests/test_api_positions.py — (#47) 포지션 조회 API
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.deps import get_conn
+
+
+@pytest.fixture
+def client(db):
+    def override():
+        yield db
+    app.dependency_overrides[get_conn] = override
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_conn, None)
+
+
+@pytest.fixture
+def seed_position(db):
+    from kr_pipeline.trade_management.store import open_position
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM position_stop_evaluations WHERE position_id IN "
+                    "(SELECT id FROM positions WHERE symbol='APITEST1')")
+        cur.execute("DELETE FROM positions WHERE symbol='APITEST1'")
+        cur.execute("INSERT INTO stocks (ticker, name, market) VALUES "
+                    "('APITEST1','에이피아이','KOSPI') ON CONFLICT DO NOTHING")
+    pid = open_position(db, symbol="APITEST1", entry_date=date(2026, 7, 1),
+                        entry_price=10000.0)
+    with db.cursor() as cur:
+        cur.execute(
+            """INSERT INTO position_stop_evaluations
+               (position_id, eval_date, close, effective_stop, binding,
+                breakeven_armed, triggered)
+               VALUES (%s, '2026-07-10', 10500, 9200, 'initial_stop', FALSE, FALSE)""",
+            (pid,))
+    db.commit()
+    yield pid
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM position_stop_evaluations WHERE position_id=%s", (pid,))
+        cur.execute("DELETE FROM positions WHERE id=%s", (pid,))
+        cur.execute("DELETE FROM stocks WHERE ticker='APITEST1'")
+    db.commit()
+
+
+def test_list_positions_with_latest_eval(client, seed_position):
+    r = client.get("/api/positions?status=open")
+    assert r.status_code == 200
+    mine = [p for p in r.json() if p["symbol"] == "APITEST1"]
+    assert len(mine) == 1
+    p = mine[0]
+    assert p["entry_price"] == 10000.0 and p["name"] == "에이피아이"
+    assert p["last_eval"]["effective_stop"] == 9200.0
+    assert p["last_eval"]["binding"] == "initial_stop"
+    assert p["last_eval"]["triggered"] is False
+
+
+def test_list_evaluations(client, seed_position):
+    r = client.get(f"/api/positions/{seed_position}/evaluations")
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) == 1 and rows[0]["close"] == 10500.0

--- a/tests/test_trade_positions.py
+++ b/tests/test_trade_positions.py
@@ -1,0 +1,255 @@
+# tests/test_trade_positions.py
+# (#47) 포지션 wiring — positions 테이블·수동 기록 store·일일 손절 평가 러너.
+# 준거: docs/superpowers/specs/2026-07-13-manage-active-trade.md §3 불변 계약,
+#       docs/superpowers/specs/2026-07-22-issue47-position-wiring.md (본 PR 사전등록)
+from datetime import date
+
+import pytest
+
+
+@pytest.mark.parametrize("table,cols", [
+    ("positions", {"symbol", "entry_date", "entry_price", "breakeven_armed",
+                   "status", "source"}),
+    ("position_stop_evaluations", {"position_id", "eval_date", "close",
+                                   "effective_stop", "binding", "triggered"}),
+])
+def test_position_tables_exist(db, table, cols):
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name=%s",
+            (table,),
+        )
+        have = {r[0] for r in cur.fetchall()}
+    missing = cols - have
+    assert not missing, f"{table} 누락 컬럼: {missing} — schema.sql 미적용?"
+
+
+def _cleanup(db, symbols):
+    with db.cursor() as cur:
+        cur.execute(
+            "DELETE FROM position_stop_evaluations WHERE position_id IN "
+            "(SELECT id FROM positions WHERE symbol = ANY(%s))", (symbols,))
+        cur.execute("DELETE FROM positions WHERE symbol = ANY(%s)", (symbols,))
+        cur.execute("DELETE FROM daily_prices WHERE ticker = ANY(%s)", (symbols,))
+        cur.execute("DELETE FROM daily_indicators WHERE ticker = ANY(%s)", (symbols,))
+        cur.execute("DELETE FROM corporate_actions WHERE ticker = ANY(%s)", (symbols,))
+        cur.execute("DELETE FROM stocks WHERE ticker = ANY(%s)", (symbols,))
+    db.commit()
+
+
+def _seed(db, symbol, *, entry_price=10000.0, entry_date=date(2026, 7, 1)):
+    from kr_pipeline.trade_management.store import open_position
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO stocks (ticker, name, market) VALUES (%s, %s, 'KOSPI') "
+            "ON CONFLICT DO NOTHING", (symbol, symbol))
+    pid = open_position(db, symbol=symbol, entry_date=entry_date,
+                        entry_price=entry_price, quantity=10, note="t")
+    db.commit()
+    return pid
+
+
+def _bar(db, symbol, d, close, *, sma_50=None):
+    with db.cursor() as cur:
+        cur.execute(
+            """INSERT INTO daily_prices (ticker, date, open, high, low, close, adj_close,
+                                         volume, value)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, 1000, 1000) ON CONFLICT DO NOTHING""",
+            (symbol, d, close, close, close, close, close))
+        if sma_50 is not None:
+            cur.execute(
+                """INSERT INTO daily_indicators (ticker, date, adj_close, sma_50)
+                   VALUES (%s, %s, %s, %s) ON CONFLICT DO NOTHING""",
+                (symbol, d, close, sma_50))
+    db.commit()
+
+
+def test_open_close_list_position(db):
+    """수동 기록 store: open → list(open) → close → list 에서 제외."""
+    from kr_pipeline.trade_management.store import (
+        open_position, close_position, get_open_positions,
+    )
+    _cleanup(db, ["POS1"])
+    pid = _seed(db, "POS1")
+    rows = get_open_positions(db)
+    mine = [r for r in rows if r["symbol"] == "POS1"]
+    assert len(mine) == 1 and mine[0]["id"] == pid
+    assert mine[0]["entry_price"] == 10000.0
+    assert mine[0]["breakeven_armed"] is False
+
+    close_position(db, position_id=pid, reason="test exit")
+    db.commit()
+    assert not [r for r in get_open_positions(db) if r["symbol"] == "POS1"]
+    _cleanup(db, ["POS1"])
+
+
+def test_daily_eval_records_and_persists_latch(db, mocker):
+    """+20% 도달일에 래치 장전·영속화, 이후 본전 하회 시 매도 신호(triggered).
+
+    시나리오: entry 10,000 → 7/10 종가 12,000(장전, breakeven 바닥) →
+    7/11 종가 9,900 < 10,000 → triggered (initial_stop 9,200 이 아니라 본전 바닥).
+    """
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS2"])
+    pid = _seed(db, "POS2")
+    notify = mocker.patch.object(runner, "notify_stop_triggered")
+
+    _bar(db, "POS2", date(2026, 7, 10), 12000.0, sma_50=9000.0)
+    r1 = runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    assert r1["evaluated"] == 1 and r1["triggered"] == 0
+    with db.cursor() as cur:
+        cur.execute("SELECT breakeven_armed FROM positions WHERE id=%s", (pid,))
+        assert cur.fetchone()[0] is True, "래치 미영속화"
+        cur.execute(
+            "SELECT effective_stop, binding, triggered FROM position_stop_evaluations "
+            "WHERE position_id=%s AND eval_date=%s", (pid, date(2026, 7, 10)))
+        stop, binding, trig = cur.fetchone()
+        assert float(stop) == 10000.0 and binding == "breakeven" and trig is False
+
+    _bar(db, "POS2", date(2026, 7, 11), 9900.0, sma_50=9000.0)
+    r2 = runner.run_daily_eval(db, as_of=date(2026, 7, 11))
+    db.commit()
+    assert r2["triggered"] == 1
+    notify.assert_called_once()
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT triggered FROM position_stop_evaluations "
+            "WHERE position_id=%s AND eval_date=%s", (pid, date(2026, 7, 11)))
+        assert cur.fetchone()[0] is True
+    _cleanup(db, ["POS2"])
+
+
+def test_daily_eval_skips_halt_and_missing_bar(db, mocker):
+    """halt(close=0)·봉 부재는 평가 대상 아님 — 스펙 §4 (러너가 사전에 거름)."""
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS3", "POS4"])
+    _seed(db, "POS3")
+    _seed(db, "POS4")
+    mocker.patch.object(runner, "notify_stop_triggered")
+    _bar(db, "POS3", date(2026, 7, 10), 0.0)  # halt 센티널
+    # POS4 는 7/10 봉 자체가 없음
+    r = runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    assert r["evaluated"] == 0
+    assert sorted(s["symbol"] for s in r["skipped"]) == ["POS3", "POS4"]
+    with db.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM position_stop_evaluations WHERE position_id IN "
+                    "(SELECT id FROM positions WHERE symbol IN ('POS3','POS4'))")
+        assert cur.fetchone()[0] == 0
+    _cleanup(db, ["POS3", "POS4"])
+
+
+def test_daily_eval_idempotent_no_duplicate_notify(db, mocker):
+    """같은 날 재실행: 평가 행 1개 유지 + Slack 중복 발송 없음."""
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS5"])
+    _seed(db, "POS5")
+    notify = mocker.patch.object(runner, "notify_stop_triggered")
+    _bar(db, "POS5", date(2026, 7, 10), 9000.0, sma_50=8000.0)  # < initial 9200 → trig
+    runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    with db.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM position_stop_evaluations WHERE position_id IN "
+                    "(SELECT id FROM positions WHERE symbol='POS5')")
+        assert cur.fetchone()[0] == 1
+    assert notify.call_count == 1, "재실행이 중복 알림 발송"
+    _cleanup(db, ["POS5"])
+
+
+def test_daily_eval_warns_on_corp_action_after_entry(db, mocker):
+    """보유 중 기업행위 발생 → entry_price 재확인 경고 (수동 기록 모델의 한계 보강)."""
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS6"])
+    pid = _seed(db, "POS6", entry_date=date(2026, 7, 1))
+    mocker.patch.object(runner, "notify_stop_triggered")
+    with db.cursor() as cur:
+        cur.execute(
+            """INSERT INTO corporate_actions (ticker, event_date, event_type)
+               VALUES ('POS6', '2026-07-05', 'split')""")
+    db.commit()
+    _bar(db, "POS6", date(2026, 7, 10), 10500.0)
+    runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT warnings FROM position_stop_evaluations WHERE position_id=%s", (pid,))
+        w = cur.fetchone()[0]
+    assert w and any("corp_action_after_entry" in x for x in w)
+    _cleanup(db, ["POS6"])
+
+
+def test_daily_eval_anchor_is_entry_price_not_classification(db, mocker):
+    """스펙 §3: anchor = 매수 시점 entry_price 고정 — 분류 테이블의 base_low/pivot
+    무유입. 분류 행(base_low 8,000)이 있어도 유효 손절선은 entry×0.92 = 9,200."""
+    from datetime import datetime, timezone
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS7"])
+    pid = _seed(db, "POS7")
+    mocker.patch.object(runner, "notify_stop_triggered")
+    with db.cursor() as cur:
+        cur.execute(
+            """INSERT INTO weekly_classification
+               (symbol, classified_at, market, classification, pivot_price, base_low, source)
+               VALUES ('POS7', %s, 'KOSPI', 'entry', 11000, 8000, 'weekend')
+               ON CONFLICT DO NOTHING""",
+            (datetime(2026, 7, 5, 3, tzinfo=timezone.utc),))
+    db.commit()
+    _bar(db, "POS7", date(2026, 7, 10), 9500.0, sma_50=9000.0)
+    runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT effective_stop, binding FROM position_stop_evaluations "
+            "WHERE position_id=%s", (pid,))
+        stop, binding = cur.fetchone()
+    assert float(stop) == 9200.0 and binding == "initial_stop", \
+        f"base_low(8000) 유입 의심: stop={stop} binding={binding}"
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM weekly_classification WHERE symbol='POS7'")
+    db.commit()
+    _cleanup(db, ["POS7"])
+
+
+def test_daily_eval_default_as_of_is_latest_bar(db, mocker):
+    """as_of 미지정 → daily_prices 최신 날짜 (cron 이 일봉 체인 뒤에 붙는 규약).
+
+    전역 MAX(date) 의존이므로 봉을 2099 센티널로 심어 다른 테스트의 잔존 봉과
+    무관하게 최댓값을 보장 (리뷰 — 전역 MAX 취약성, full suite 실측으로 확증됨).
+    """
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS8"])
+    _seed(db, "POS8")
+    mocker.patch.object(runner, "notify_stop_triggered")
+    sentinel = date(2099, 7, 10)
+    _bar(db, "POS8", sentinel, 10500.0)
+    try:
+        r = runner.run_daily_eval(db)  # as_of=None
+        db.commit()
+        assert r["as_of"] == sentinel and r["evaluated"] >= 1
+    finally:
+        _cleanup(db, ["POS8"])
+
+
+def test_daily_eval_skips_backdated_as_of(db, mocker):
+    """(2기 리뷰 F-1) 이미 더 나중 날짜가 평가된 포지션에 과거 as_of 재실행 →
+    미평가 과거일이라도 skip — 현재 래치를 과거에 소급 적용하는 시대착오 차단."""
+    from kr_pipeline.trade_management import runner
+    _cleanup(db, ["POS9"])
+    _seed(db, "POS9")
+    mocker.patch.object(runner, "notify_stop_triggered")
+    _bar(db, "POS9", date(2026, 7, 10), 12000.0)  # 장전
+    _bar(db, "POS9", date(2026, 7, 8), 9000.0)    # 과거일 (트리거였을 값)
+    runner.run_daily_eval(db, as_of=date(2026, 7, 10))
+    db.commit()
+    r = runner.run_daily_eval(db, as_of=date(2026, 7, 8))  # backdated
+    db.commit()
+    assert r["evaluated"] == 0
+    assert r["skipped"] and r["skipped"][0]["reason"] == "backdated_as_of"
+    with db.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM position_stop_evaluations WHERE position_id IN "
+                    "(SELECT id FROM positions WHERE symbol='POS9')")
+        assert cur.fetchone()[0] == 1, "과거일 평가 행이 생성됨 (시대착오)"
+    _cleanup(db, ["POS9"])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Sparkles,
   FileArchive,
   Zap,
+  Briefcase,
   TrendingUp,
   Wrench,
   ListChecks,
@@ -24,6 +25,7 @@ import ChartPage from "./pages/ChartPage";
 import MinerviniPage from "./pages/MinerviniPage";
 import PromptPage from "./pages/PromptPage";
 import SignalsPage from "./pages/SignalsPage";
+import PositionsPage from "./pages/PositionsPage";
 import PerformancePage from "./pages/PerformancePage";
 import RunnerPage from "./pages/RunnerPage";
 import ClassificationsPage from "./pages/ClassificationsPage";
@@ -54,6 +56,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/classifications", label: "Classifications", kr: "LLM 분류", Icon: ListChecks },
   { to: "/triggers", label: "Triggers", kr: "트리거 이력", Icon: Activity },
   { to: "/signals", label: "Signals", kr: "시그널", Icon: Zap },
+  { to: "/positions", label: "Positions", kr: "포지션", Icon: Briefcase },
   { to: "/performance", label: "Performance", kr: "시그널 성과", Icon: TrendingUp },
 
   // ─── 메타 문서 / 운영 ──────────────────────
@@ -253,6 +256,7 @@ function App() {
           <Route path="/chart/:ticker" element={<ChartPage />} />
           <Route path="/minervini" element={<MinerviniPage />} />
           <Route path="/signals" element={<SignalsPage />} />
+          <Route path="/positions" element={<PositionsPage />} />
           <Route path="/performance" element={<PerformancePage />} />
           <Route path="/classifications" element={<ClassificationsPage />} />
           <Route path="/triggers" element={<TriggersPage />} />

--- a/web/src/pages/PositionsPage.tsx
+++ b/web/src/pages/PositionsPage.tsx
@@ -1,0 +1,129 @@
+import { useQuery } from "@tanstack/react-query";
+import { Briefcase, AlertTriangle } from "lucide-react";
+import { api } from "../lib/api";
+import { Skeleton } from "../components/ui/Skeleton";
+
+// (#47) 보유 포지션 + 일일 손절 평가 — 수동 기록 모델 (등록/종료는 CLI:
+// python -m kr_pipeline.trade_management --add/--close-id)
+
+interface LastEval {
+  eval_date: string;
+  close: number | null;
+  sma_50: number | null;
+  effective_stop: number | null;
+  binding: string;
+  triggered: boolean;
+  warnings: string[];
+}
+
+interface Position {
+  id: number;
+  symbol: string;
+  name: string | null;
+  entry_date: string;
+  entry_price: number | null;
+  quantity: number | null;
+  breakeven_armed: boolean;
+  status: string;
+  note: string | null;
+  last_eval: LastEval | null;
+}
+
+function fmtPrice(n: number | null | undefined): string {
+  if (n == null) return "—";
+  return `₩${n.toLocaleString("ko-KR")}`;
+}
+
+const BINDING_LABEL: Record<string, string> = {
+  initial_stop: "초기 -8%",
+  breakeven: "본전 바닥",
+  sma50_trail: "50일선 추적",
+};
+
+export default function PositionsPage() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["positions"],
+    queryFn: () => api<Position[]>("/positions?status=open"),
+  });
+
+  if (isLoading) return <Skeleton className="h-64" />;
+  if (isError)
+    return (
+      <p className="text-sm text-red-600">
+        포지션 조회 실패 — API 서버 상태를 확인하세요.
+      </p>
+    );
+  const rows = data ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Briefcase className="h-5 w-5" />
+        <h1 className="text-xl font-semibold">보유 포지션</h1>
+        <span className="text-sm text-muted-foreground">
+          {rows.length}건 · 일일 손절 평가(3층 스택)
+        </span>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          open 포지션이 없습니다. 등록:{" "}
+          <code>python -m kr_pipeline.trade_management --add SYMBOL --price P</code>
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="py-2 pr-3">종목</th>
+                <th className="py-2 pr-3">매수일</th>
+                <th className="py-2 pr-3">평균매입가</th>
+                <th className="py-2 pr-3">평가일</th>
+                <th className="py-2 pr-3">종가</th>
+                <th className="py-2 pr-3">유효 손절선</th>
+                <th className="py-2 pr-3">바인딩</th>
+                <th className="py-2 pr-3">상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((p) => (
+                <tr key={p.id} className="border-b">
+                  <td className="py-2 pr-3 font-medium">
+                    {p.symbol}
+                    {p.name ? <span className="ml-1 text-muted-foreground">{p.name}</span> : null}
+                  </td>
+                  <td className="py-2 pr-3">{p.entry_date}</td>
+                  <td className="py-2 pr-3">{fmtPrice(p.entry_price)}</td>
+                  <td className="py-2 pr-3">{p.last_eval?.eval_date ?? "—"}</td>
+                  <td className="py-2 pr-3">{fmtPrice(p.last_eval?.close)}</td>
+                  <td className="py-2 pr-3">{fmtPrice(p.last_eval?.effective_stop)}</td>
+                  <td className="py-2 pr-3">
+                    {p.last_eval ? BINDING_LABEL[p.last_eval.binding] ?? p.last_eval.binding : "—"}
+                    {p.breakeven_armed ? (
+                      <span className="ml-1 rounded bg-emerald-100 px-1 text-xs text-emerald-700 dark:bg-emerald-900 dark:text-emerald-200">
+                        장전
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-2 pr-3">
+                    {p.last_eval?.triggered ? (
+                      <span className="inline-flex items-center gap-1 rounded bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900 dark:text-red-200">
+                        <AlertTriangle className="h-3 w-3" /> 매도 신호
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">보유</span>
+                    )}
+                    {p.last_eval?.warnings?.length ? (
+                      <span className="ml-1 text-xs text-amber-600" title={p.last_eval.warnings.join("; ")}>
+                        ⚠
+                      </span>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #47

## 결정·준거
포지션 소스 = **수동 기록**(2026-07-22 사용자 확정, source 컬럼 어댑터 구조로 브로커 연동 교체 가능). 스펙 §5(2026-07-13-manage-active-trade.md) 예약분 이행 — 사전등록 `specs/2026-07-22-issue47-position-wiring.md` + §3 불변 계약 승계 체크리스트 전항 준수(anchor=entry_price 고정·base_low 재사용 금지·래치 단조·halt/결측 skip·분류 상태 독립·전량 신호만).

## 변경
- **schema.sql** — `positions`(open 1개/종목 partial unique, quantity CHECK) + `position_stop_evaluations`(멱등 PK, FK는 의도적 no-CASCADE). ⚠머지 후 psql 양쪽 적용
- **runner.run_daily_eval** — open 포지션 × `evaluate_stop`(PR #40 코어): 래치 영속(단조 True), halt/결측 skip, `corp_action_after_entry` 경고(경계 ≥ 매수일), **backdated as_of 거부**(현재 래치의 과거 소급 차단 — 리뷰 Important), 신규 insert 시에만 Slack(중복 알림 방지, eval_date 명시)
- **CLI** `python -m kr_pipeline.trade_management` (--add/--close-id/--list/--mode=daily-eval, run_tracking 통합)
- **API** `/api/positions`(+`/{id}/evaluations`, LATERAL 최신 평가) + **웹** `/positions` 페이지(빌드 검증)
- 러너는 분류 테이블(weekly_classification)을 **조회조차 하지 않음** — 리뷰가 grep 으로 확증

## 검증
- TDD 12건(RED 선행): 래치 영속·본전 트리거·halt/결측·멱등·중복 알림 방지·corp-action 경고·anchor 절연(분류 행 오염 주입 테스트)·backdated 거부·기본 as_of + API 2건
- 전체 스위트 **1083 passed / 0 failed** — 리뷰가 지적한 전역 MAX 테스트 취약성이 1차 full suite 에서 실제 발화(1건 실패)해 2099 센티널로 수리, 재실행 clean
- 독립 코드리뷰 1기: Critical 0·Important 2(backdated 시대착오·테스트 취약성) 반영, minor 8건 중 7건 반영(트랜잭션 내 notify 타이밍은 후속 노트)

## ⚠ 머지 체크리스트
```
psql -d kr_pipeline -f kr_pipeline/db/schema.sql
psql -d kr_test -f kr_pipeline/db/schema.sql
```
(경합 시 표적 CREATE TABLE/INDEX + lock_timeout — #50 교훈. 신규 테이블이라 기존 테이블 락은 없음)
cron 제안(별도 승인): `10 19 * * 1-5 ... trade_management --mode=daily-eval` — 일봉 체인(최근 최대 26분) 종료 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)