### PR TITLE
#74 cup_without_handle 수용 — taxonomy + 보수 장치 2 + 사전등록 F1~F4

### DIFF
--- a/docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md
+++ b/docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md
@@ -1,8 +1,11 @@
 # #74 cup_without_handle 수용 — 구현 스펙 + 의존성 맵 (2026-07-24)
 
-> **상태: DRAFT** — 독립 설계 리뷰 1회 반영본(차단 5·비차단 7 전부 처리).
-> 사용자 게이트 승인 시 구현 착수. 준거: 이슈 #74(외부 red-team A 권고,
-> 사용자 확정 07-22) + 독립 리뷰(07-24). 관례: TDD·구현 후 독립 리뷰·머지 게이트.
+> **상태: 승인 — 구현 착수 (2026-07-24 사용자 게이트)** — 독립 설계 리뷰
+> + 스펙 재검토(차단 2·자체 1·권고 8 반영) 완료본. 준거: 이슈 #74(외부
+> red-team A 권고, 사용자 확정 07-22) + 독립 리뷰 2회(07-24).
+> 관례: TDD·구현 후 독립 리뷰·머지 게이트. **배포 원자성: 프롬프트+코드+
+> web 동기를 단일 PR 로 원자 배포**(프롬프트 선행 배포 시 보수 장치 없이
+> 라이브 노출 — 금지).
 
 ## 1. 변경 요약 (6항)
 
@@ -30,16 +33,22 @@
     watch(`valid_base_awaiting_breakout`) / 0.95~1.05 = entry / >1.05 =
     extended. (구 :165 의 `handle_status=not_formed` + 일괄 watch 는 이
     분기에서 폐기 — 핸들 미형성이 더는 base 미완성이 아님)
-  - 우측 회복 미완 → `base_forming` 유지.
-- **우측 회복 완료 (신설 경계, design-judgment)**: 컵 우측이
-  **current ≥ pivot × CUP_NH_RECOVERY_MIN(0.90)** 까지 회복 + U자 바닥
-  rounding 완성(LLM 형상 판정). 근거: base "상반부" 관례 — 핸들 정상 깊이
-  상한 12%(§4 handle depth)와 정합하는 상단 존(~10%). 0.90 미만은 우측
-  벽 미완 = base_forming. **프롬프트 전용값**(코드 비소비) — SSOT 비등재
-  원칙(#19 전례), A↔재분류 flip-flop 은 F-부록 관측 대상.
-- **:540 base_forming 예시·이탤릭 근거 문장 재작성**(리뷰 비차단 12):
-  "cup 완성+handle 미형성" 예시 제거, *shakeout 부재 리스크는 배제가 아니라
-  보수 장치(§3·§4)로 흡수한다* 로 교체.
+  - 우측 회복 미완 → **`pattern=cup_with_handle` + `handle_status=not_formed`
+    + `base_forming`** (구 :165 라벨 연속성 유지 — pattern_changed sanity·
+    코호트 통계 연속, 재검토 차단 A-①).
+- **우측 회복 완료 (신설 경계, design-judgment)**: 컵 바닥 이후 우측 구간의
+  **최고 종가 ≥ pivot × CUP_NH_RECOVERY_MIN(0.90)** — **도달치 기준(래칫)**:
+  한번 완성이면 이후 조정으로 현재가가 0.90 아래로 밀려도 완성 상태 유지,
+  현재가의 위치 판정은 §8.5 가격 밴드가 담당(재검토 차단 A-③ — 주간
+  flip-flop 차단). + U자 바닥 rounding 완성(LLM 형상 판정). 근거: base
+  "상반부" 관례 — 핸들 정상 깊이 상한 12%(§4 handle depth)와 정합하는 상단
+  존(~10%). **프롬프트 전용값**(코드 비소비) — SSOT 비등재 원칙(#19 전례),
+  A↔재분류 flip-flop 은 F-부록 관측 대상.
+- **:540 base_forming 재작성**(리뷰 비차단 12 + 재검토 차단 A-②):
+  "cup 완성+handle 미형성" 예시를 **"cup 우측 회복 미완(최고 종가 <
+  CUP_NH_RECOVERY_MIN×cup high)"** 예시로 교체(D4 우선 규칙의 앵커 유지),
+  이탤릭 근거 문장은 *shakeout 부재 리스크는 배제가 아니라 보수 장치
+  (§3·§4)로 흡수한다* 로 교체.
 - **§4.7 pivot 표 행 추가** + `pivot_basis="cup_high"` 신설: §9 enum ·
   `store._PIVOT_TABLE_BASES` 에 등록(+tick 사후검증 적용 — 리뷰 비차단 7).
 - §7 :511 대비 문장에 "cup_without_handle 은 high of the cup" 병기(비차단 6).
@@ -51,17 +60,21 @@
   분류분 breakout 포함**) 후, `pattern == cup_without_handle` 이고
   `volume_ratio < BREAKOUT_VOL_PREFERRED(1.5)` 면 LLM 미호출 +
   `wait_reason='volume_below_strict_no_handle'` 기록(원값 volume_ratio·
-  close·pivot 동반 — F4 측정 재료).
-- **순서: extended 인터셉트(#45) 선행** — extended 차단분이 F4 코호트
-  (거래량 floor 에서만 차단)에 오염되지 않게.
+  close·pivot 동반 — F4 측정 재료). volume 또는 avg_volume_50d 결측 시
+  인터셉트 **비발동**(기존 LLM 경로 — 결측을 차단 근거로 쓰지 않음, 보수는
+  §6 warning 이 담당).
+- **인터셉트 체인 순서: dedupe(§5) → extended(#45) → strict** —
+  보유 억제분·extended 차단분이 F4 분모("strict 에서만 차단")에 오염되지
+  않게(재검토 권고 3 — dedupe 최선행: 보유자에겐 extended wait 기록도 노이즈).
 - grace band(1.2~1.4 wait)·1.4 floor 는 이 패턴에 **비적용**(강한 쪽 단일
   기준). 발화 임계 자체(GATE_BREAKOUT_VOL_MULT=1.0)는 불변 — 발화 후
   차단 방식(#45 동형, 보수화만).
 - entry_params_calc §6: 이 패턴이면 `vol_req="ge_1.5x_strict"` 표기.
   1.4~1.5 warning 은 B 인터셉트 선행으로 도달 불가(동일 데이터) — 유지.
 - 주말 A-경로 §8 :519(1.4~1.5×)에 패턴 각주 추가: cup_without_handle 은
-  1.5× 미만이면 entry 로 판정하지 말 것(비차단 11 — 실매수는 B 가 막지만
-  A/B 서사 일관성).
+  **돌파를 근거로 entry 판정할 때에 한해** 1.5× 미만이면 entry 로 판정하지
+  말 것(재검토 권고 8 — 돌파 전 밴드 내(0.95~1.05) entry 는 §8.5 밴드
+  규칙 그대로, 거래량 조건 비적용). 실매수는 B 가 막지만 A/B 서사 일관성.
 - **pocket pivot 우회 차단**: `_PP_BASE_PATTERNS`·§4.5 에 cup_without_handle
   **의도적 미포함** 명기(비차단 10) — PP 시그니처로 strict 우회 불가.
 
@@ -116,17 +129,27 @@
 ### 6.1 측정 규약 부록 (리뷰 차단⑤ 해소 — 원문 비수정, 조작화만)
 
 - **코호트 이중 정의**: ⓐ 체결 코호트 = `positions` 와 (symbol,
-  entry_date±1영업일) join(수동 기록 규약 — #47). ⓑ **신호 코호트** =
-  go_now 행 기준 OHLCV 가상 추적(진입가=신호일 종가) — 체결 0건 구간에도
-  F1~F3 을 신호 기준으로 병행 판정(주 판정은 체결 코호트, 신호 코호트는
-  체결 표본 부족 시 대체 + 항상 병행 보고).
-- **F1**: 스탑아웃 = 가상/실제 손절가(TRADE_STOP_INITIAL_PCT −8%) 터치,
-  창 = 진입 후 8주. **F2**: 창 = 진입 후 8주(F1 동일), "조기실패" = 종가
-  기준 pivot 하회 복귀 AND 최고 도달 < 진입가×1.05. **F3**: 실현손실 =
-  청산(실제 또는 신호 코호트는 8주 창 종료가) 손실률 절대값.
+  go_now 행의 `analyzed_for_date`±1영업일) join(수동 기록 규약 — #47,
+  앵커 = 신호일). ⓑ **신호 코호트** = go_now 행 기준 OHLCV 가상 추적
+  (진입가=신호일 종가) — 체결 0건 구간에도 F1~F3 을 신호 기준으로 병행
+  판정(주 판정은 체결 코호트, 신호 코호트는 체결 표본 부족 시 대체 +
+  항상 병행 보고).
+- **F1**: 스탑아웃 = 손절가 터치, 창 = 진입 후 8주. 손절가 = **go_now 행의
+  `entry_params.stop_loss_price`**(신호·체결 코호트 공통 — 실제 규율과
+  단일 정의, 재검토 권고 5), 그 값 결측 시에만 TRADE_STOP_INITIAL_PCT
+  −8% 폴백(폴백 사용 행 태그).
+- **F2**: 창 = 진입 후 8주(F1 동일), "조기실패" = 종가 기준 pivot 하회
+  복귀 AND 최고 도달 < 진입가×1.05. **F3**: 실현손실 = **손실 트레이드
+  한정** 평균/중앙값(청산가 = 실제, 신호 코호트는 8주 창 종료가 —
+  재검토 권고 6).
 - **F4**: 분모 = `wait_reason='volume_below_strict_no_handle'` **행 단위**
   (동일 종목 복수 행 허용 — 차단 이벤트가 단위), 기준가 = 차단 당시
   pivot, 창 = 차단 후 8주, "20%+ 상승" = 최고가 ≥ pivot×1.20.
+  **경로 비대칭 기록**(재검토 권고 4): breakout_from_watch 는 fresh_cross
+  탓에 차단 다음날 재발화가 구조적으로 제한, entry 경로 breakout 은 매일
+  발화 가능 → 행 단위 분모가 entry-분류 종목을 과대표집. 판독 시 행 단위
+  + **종목-에피소드 단위 병행 보고**. 보유 억제분(§5)은 체인 선행으로
+  분모 비포함.
 - **판정 시점**: 첫 판독 = 코호트 최소 크기 도달 시(recall 감사 프레임
   — go_now ≥20 선례 #45). 그 전 관측치는 참고 보고만.
 
@@ -136,7 +159,7 @@
 행 / flag 주입 → `no_handle_shakeout_absent` → 사이징·경고 / 신 pattern 값 →
 분류·pivot_basis·트리거 경로 전파.
 
-**2단계(소비 룰)**: evaluate_pivot 인터셉트 체인(#45 extended → 신규 strict →
+**2단계(소비 룰)**: evaluate_pivot 인터셉트 체인(신규 dedupe → #45 extended → 신규 strict →
 dedupe) / entry_params_calc 티어·배수·vol_req / trigger_gate(발화 —
 GATE_BREAKOUT_VOL_MULT) / prompt §8.5 밴드·D4.
 
@@ -148,7 +171,9 @@ GATE_BREAKOUT_VOL_MULT) / prompt §8.5 밴드·D4.
 | BREAKOUT_VOL_FLOOR=1.4 / WAIT_FLOOR=1.2 | 가능 | **미미** — 이 패턴 한정 비적용(타 패턴 경로 불변). 비적용이 명시적 분기라 상호작용 없음 | EXTENDS | 모니터링(근거: 분기 조건이 pattern 등가 비교 단일 지점) |
 | GATE_BREAKOUT_VOL_MULT=1.0 (발화) | 가능 | **미미** — 발화 집합 불변, 발화 후 차단만 추가(#45 동형·보수화만) | EXTENDS | 모니터링(근거: 발화 임계 비접촉 — F4 분모가 발화 후 차단분을 전수 포착) |
 | PIVOT_EXTENDED_BAND_MULT=1.05 (#45 인터셉트) | 가능 | **있음** — 인터셉트 순서가 F4 분모를 결정(extended 선행 안 하면 코호트 오염) | EXTENDS | 순서 명문화(§3) + 테스트로 고정 |
-| HANDLE_LEGIT_MIN_DAYS=5 (Gate3 경계) | 불가(일수) | **있음** — with/without 분기점으로 역할 확장(구: watch 강등점). 5일 자체는 불변 | design-judgment(HMMS 예외 하한 채택 기존 태그) | 값 불변·역할 확장 — F1~F3 비교군 정의가 이 경계에 의존함을 §6.1 에 기록 |
+| HANDLE_LEGIT_MIN_DAYS=5 (Gate3 경계) | 불가(일수) | **있음** — with/without 분기점으로 역할 확장(구: watch 강등점). 5일 자체는 불변 | design-judgment(HMMS 예외 하한 채택 기존 태그) | **B-수치**: F1~F3 첫 판독에 경계 의존성 검토 동반(비교군 정의가 이 경계에 의존 — 규칙 형식 정정, 자체 검토 C) |
+| GATE_PROMOTION_PRICE_RATIO=0.95 (§8.5 밴드·promotion 발화 겸용) | 가능(비율) | **있음** — 신설 0.90 과 이중 경계 형성(0.90~0.95 = watch 대기존), promotion 발화 임계 겸용이라 신 패턴 watch→entry 승격도 이 값이 결정 | design-judgment(§8.5 명기 — promotion 임계와 정합 설계) | 값 불변 — 이중 경계 상호작용은 CUP_NH 행의 B-수치(flip-flop·경계 분포 판독)에 통합(재검토 차단 B) |
+| ENTRY_WEIGHT_PCT_MIN=3.0 (사이징 하한) | 가능 | **미미** — F1~F3 발화 시 ×0.5 강화해도 7.0×0.5=3.5 > 3.0 (하한 비충돌 여유 확인) | EXTENDS | 모니터링(근거: 강화 1회 시나리오까지 하한 여유 실측 — 재검토 권고) |
 | CUP_NH_RECOVERY_MIN=0.90 (신설, 프롬프트 전용) | 가능(비율) | **있음** — base_forming↔신 패턴 경계. 0.95(§8.5 밴드)와 이중 경계 형성: 0.90~0.95 = watch 대기존 | design-judgment(핸들 깊이 12% 존과 정합) | **B-수치**: 재분류 flip-flop 률·경계 분포를 첫 판독에 동반(코드 비소비 — SSOT 비등재, #19 전례) |
 | `_FLAG_MULT` 0.7 (신설 값) | 가능 | **있음** — 실효 4.9pp 를 결정(티어 7.0 fallback 과 곱) | design-judgment(Minervini pilot 보수화 표 관례) | F1~F3 발화 시 ×0.5 강화 1회(사전등록 §6 판정 규칙이 후속을 이미 등록) |
 | `_SIZE_FALLBACK_STD`=7.0 (소비) | 가능 | **있음** — flag 주입이 이 티어를 상시 선택(standard 10.0 도달 불능 — dead code 사유로 _STANDARD_PATTERNS 비등재) | EXTENDS | 값 불변 — #80(이중 구조 전면 재검토)로 이관 |
@@ -162,12 +187,21 @@ positions(수동) — 신 패턴은 이 4층을 전부 통과하며, 각 층의 
 
 - **비변경**: Gate2 V 배제, 발화 임계, 타 패턴 경로 전부, `handle_quality`
   backstop(pattern≠cup_with_handle 자동 skip — 리뷰 확인), §6.1/§6.2 게이트.
-- **TDD 목록**: ① Gate3 분기(프롬프트 게이트 테스트 — tests/test_prompt_*
-  관례) ② strict 인터셉트(1.49 차단·1.5 통과·extended 선행 순서·타 패턴
-  비적용) ③ flag 주입 멱등+4.9pp 실효 ④ dedupe(상향 한정·invalidation
-  비억제) ⑤ pivot_basis cup_high +tick 사후검증 ⑥ vol_req 표기.
-- **수동 동기화 목록**(비차단 9): `verify_analysis_v1.md:12` 패턴 카운트,
-  analyze §Forbidden :678 "9→10-value", web `base-patterns.ts`·
-  `entry-params-fields.ts:35`(vol_req enum)·`stages.ts:270`. thresholds.py
-  변경 없음(신설 상수 0 — 프롬프트 전용값 원칙) → export 재실행 불요.
+- **TDD 목록**: ① Gate3 분기·§8 각주·:540 재작성·§4 블록의 프롬프트
+  텍스트 검증(tests/test_prompt_* 드리프트 관례 — **LLM 행동 검증은
+  재실행 비교 금지 규율상 불가, 텍스트 검증까지가 한계** 명기) ② strict
+  인터셉트(1.49 차단·1.5 통과·체인 순서 dedupe→extended→strict·타 패턴
+  비적용·**volume/avg 결측 시 비발동 폴백**) ③ flag 주입 멱등+4.9pp 실효
+  +**`size_reduced_due_to_no_handle_shakeout` 경고 방출·우선순위 등재**
+  ④ dedupe(상향 한정 — breakout·breakout_from_watch·**promotion 각각
+  억제 케이스**·invalidation 비억제·**억제 행 기록값 스키마**) ⑤
+  pivot_basis cup_high +tick 사후검증 ⑥ vol_req="ge_1.5x_strict" 표기.
+- **수동 동기화 목록**(비차단 9 + 재검토 권고 7): `verify_analysis_v1.md:12`
+  패턴 카운트, analyze §Forbidden :678 "9→10-value", web `base-patterns.ts`·
+  `entry-params-fields.ts:35`(vol_req enum)·`stages.ts:270`·
+  **`ClassificationsPage.tsx:68` PATTERN_DESCRIPTIONS**·
+  **`prompt-explanations.ts:28,37` "9 base 패턴" 카운트 2곳**.
+  `scripts/remeasure_phase2i.py:19` 는 superseded 주석(구 Gate3 기대문).
+  thresholds.py 변경 없음(신설 상수 0 — 프롬프트 전용값 원칙) → export
+  재실행 불요.
 - **F1~F4 배포**: 본 문서 §6 이 등록본. 구현 PR 머지 시점부터 코호트 발생.

--- a/docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md
+++ b/docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md
@@ -159,8 +159,8 @@
 행 / flag 주입 → `no_handle_shakeout_absent` → 사이징·경고 / 신 pattern 값 →
 분류·pivot_basis·트리거 경로 전파.
 
-**2단계(소비 룰)**: evaluate_pivot 인터셉트 체인(신규 dedupe → #45 extended → 신규 strict →
-dedupe) / entry_params_calc 티어·배수·vol_req / trigger_gate(발화 —
+**2단계(소비 룰)**: evaluate_pivot 인터셉트 체인(신규 dedupe → #45 extended →
+신규 strict) / entry_params_calc 티어·배수·vol_req / trigger_gate(발화 —
 GATE_BREAKOUT_VOL_MULT) / prompt §8.5 밴드·D4.
 
 **3단계(룰 내부 고정 상수) — 상수별 2축**:

--- a/docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md
+++ b/docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md
@@ -1,0 +1,173 @@
+# #74 cup_without_handle 수용 — 구현 스펙 + 의존성 맵 (2026-07-24)
+
+> **상태: DRAFT** — 독립 설계 리뷰 1회 반영본(차단 5·비차단 7 전부 처리).
+> 사용자 게이트 승인 시 구현 착수. 준거: 이슈 #74(외부 red-team A 권고,
+> 사용자 확정 07-22) + 독립 리뷰(07-24). 관례: TDD·구현 후 독립 리뷰·머지 게이트.
+
+## 1. 변경 요약 (6항)
+
+| # | 항목 | 위치 |
+|---|---|---|
+| 1 | taxonomy `cup_without_handle` 신설 | prompt §4·§4.7·§8.6·§9 + store `_PIVOT_TABLE_BASES` + web 동기 |
+| 2 | Gate3 분기: 컵 완성+핸들<5일 → 신 패턴 | prompt §4 Gate3·§8.5 |
+| 3 | strict 1.5× 돌파 거래량 (결정론 인터셉트) | `evaluate_pivot.py` (#45 전례) |
+| 4 | 사이징: flag `no_handle_shakeout_absent` ×0.7 | `entry_params_calc.py` |
+| 5 | 이중 진입 방지 (상향 트리거 한정) | `evaluate_pivot.py` + `trade_management.store` |
+| 6 | 사전등록 F1~F4 (원문 불변) + 측정 규약 부록 | 본 문서 §6 |
+
+## 2. taxonomy·Gate3 (리뷰 차단③ 해소 — 경계 정량화)
+
+- **§4 정의 블록**: 컵 기준은 cup_with_handle 과 동일(U자·7~45주·depth
+  ≤CUP_DEPTH_MAX(33%)/베어 회복 50%·선행상승 ≥30%) — 핸들 요소 없음.
+  태그: **book-mandated** (HMMS 5대 모델 장 — cup-without-handle 명명 실재).
+  Gate2 V자 배제는 **완화 없이 그대로 적용**(변경 없음).
+- **Gate3 재분기** (길이 우선 규칙 유지, :165 대체):
+  - 핸들 ≥ HANDLE_LEGIT_MIN_DAYS(5일) → `cup_with_handle` (기존 그대로,
+    pivot=handle_high — 핸들이 완성되면 그쪽이 우월 pivot)
+  - 핸들 < 5일(0일 = 시도 없음 포함) + **우측 회복 완료** →
+    `pattern=cup_without_handle`, pivot = **컵 내 절대 고점** + KR tick
+    관례(§7). classification 은 §8.5 가격 밴드 그대로: <0.95×pivot =
+    watch(`valid_base_awaiting_breakout`) / 0.95~1.05 = entry / >1.05 =
+    extended. (구 :165 의 `handle_status=not_formed` + 일괄 watch 는 이
+    분기에서 폐기 — 핸들 미형성이 더는 base 미완성이 아님)
+  - 우측 회복 미완 → `base_forming` 유지.
+- **우측 회복 완료 (신설 경계, design-judgment)**: 컵 우측이
+  **current ≥ pivot × CUP_NH_RECOVERY_MIN(0.90)** 까지 회복 + U자 바닥
+  rounding 완성(LLM 형상 판정). 근거: base "상반부" 관례 — 핸들 정상 깊이
+  상한 12%(§4 handle depth)와 정합하는 상단 존(~10%). 0.90 미만은 우측
+  벽 미완 = base_forming. **프롬프트 전용값**(코드 비소비) — SSOT 비등재
+  원칙(#19 전례), A↔재분류 flip-flop 은 F-부록 관측 대상.
+- **:540 base_forming 예시·이탤릭 근거 문장 재작성**(리뷰 비차단 12):
+  "cup 완성+handle 미형성" 예시 제거, *shakeout 부재 리스크는 배제가 아니라
+  보수 장치(§3·§4)로 흡수한다* 로 교체.
+- **§4.7 pivot 표 행 추가** + `pivot_basis="cup_high"` 신설: §9 enum ·
+  `store._PIVOT_TABLE_BASES` 에 등록(+tick 사후검증 적용 — 리뷰 비차단 7).
+- §7 :511 대비 문장에 "cup_without_handle 은 high of the cup" 병기(비차단 6).
+
+## 3. strict 1.5× 돌파 거래량 (리뷰 차단① 해소 — 인터셉트 지점 교정)
+
+- **지점 = `evaluate_pivot.py` 결정론 인터셉트**(#45 extended 전례·기록
+  기계 재사용): 트리거 발화(breakout·breakout_from_watch — **주말 entry
+  분류분 breakout 포함**) 후, `pattern == cup_without_handle` 이고
+  `volume_ratio < BREAKOUT_VOL_PREFERRED(1.5)` 면 LLM 미호출 +
+  `wait_reason='volume_below_strict_no_handle'` 기록(원값 volume_ratio·
+  close·pivot 동반 — F4 측정 재료).
+- **순서: extended 인터셉트(#45) 선행** — extended 차단분이 F4 코호트
+  (거래량 floor 에서만 차단)에 오염되지 않게.
+- grace band(1.2~1.4 wait)·1.4 floor 는 이 패턴에 **비적용**(강한 쪽 단일
+  기준). 발화 임계 자체(GATE_BREAKOUT_VOL_MULT=1.0)는 불변 — 발화 후
+  차단 방식(#45 동형, 보수화만).
+- entry_params_calc §6: 이 패턴이면 `vol_req="ge_1.5x_strict"` 표기.
+  1.4~1.5 warning 은 B 인터셉트 선행으로 도달 불가(동일 데이터) — 유지.
+- 주말 A-경로 §8 :519(1.4~1.5×)에 패턴 각주 추가: cup_without_handle 은
+  1.5× 미만이면 entry 로 판정하지 말 것(비차단 11 — 실매수는 B 가 막지만
+  A/B 서사 일관성).
+- **pocket pivot 우회 차단**: `_PP_BASE_PATTERNS`·§4.5 에 cup_without_handle
+  **의도적 미포함** 명기(비차단 10) — PP 시그니처로 strict 우회 불가.
+
+## 4. 사이징 (리뷰 차단② 해소 — 수치 전제 정정)
+
+- `calculate_entry_params` 에서 `pattern == cup_without_handle` 이면
+  `no_handle_shakeout_absent` 를 raw_flags 에 **결정론 주입**(멱등).
+- `_FLAG_MULT["no_handle_shakeout_absent"] = 0.7` + `_MULT_WARNING`
+  (`size_reduced_due_to_no_handle_shakeout`) + `_WARNING_PRIORITY` 등록.
+- **실효 사이징 = 7.0(fallback 티어) × 0.7 = 4.9pp** — 표준 경로 티어
+  실물(15/10/5risky/7fallback, :37) 재확인. 정정 이력: 설계 문답 당시
+  pocket 상수(10/7/5) 오인 → 사용자 결정(이중 페널티 수용, 예외 코드 없음)
+  의 취지 유지·수치만 3.5→4.9pp 정정(#80 본문 동시 정정, 07-24).
+- `_STANDARD_PATTERNS` 에 **추가하지 않음** — flag 상시 주입으로 no_flags
+  항상 False = standard 티어 도달 불능(dead code). 사유 주석 명기(리뷰 차단②).
+- `RISK_FLAGS_TAXONOMY`(§5/store) 에 **넣지 않음** — C단계 로컬 주입 전용,
+  LLM 이 emit 하면 store 가 drop(현행 동작 유지). 프롬프트에 flag 명 비노출
+  (비차단 8).
+
+## 5. 이중 진입 방지 (리뷰 차단④ 해소 — 범위 한정)
+
+- `evaluate_pivot` 의 **상향 트리거(breakout·breakout_from_watch·promotion)
+  한정**: 해당 티커에 open position 존재(`trade_management.store` 조회) 시
+  트리거 억제 + 억제 행 기록(`suppressed_position_held`).
+  **invalidation(손절·50일선 이탈)은 억제하지 않음** — 보유자 필수 신호.
+- 범위 판단: 이슈 원문은 "동일 base" 단위이나 base 식별 매칭이 취약 →
+  **티커 단위 상위집합**(보수). 패턴 무관 전 종목 적용 — B v3 확정(단순
+  abort·피라미딩 없음)과 정합해 보유 중 상향 재트리거는 전부 노이즈.
+  이슈 스코프(동일 base) 초과분은 게이트에서 확정.
+
+## 6. 사전등록 F1~F4 — 외부 검토 원문 (불변 등록)
+
+```
+[사전등록] cup_without_handle 수용 검증 — A 채택 시
+대상: pattern=cup_without_handle 로 진입한 전체 트레이드 (코호트 태그 필수)
+비교군: 동일 기간 pattern=cup_with_handle 진입
+지표 (모두 저장본 1회 분석, 재실행 비교 금지):
+  F1. 스탑아웃률(진입 후 8주 내): no-handle 코호트가 with-handle 대비
+      +15pp 초과 OR 1.5배 초과 → 보수 장치 불충분 판정
+  F2. 조기실패율: 돌파 후 +5% 미달 상태에서 pivot 하회 복귀 비율
+      — with-handle 대비 2배 초과 → 판정 동일
+  F3. 손실 규율: no-handle 코호트 단독으로 평균 실현손실 ≤9% /
+      중앙값 <10% hard 기준 위반 → 즉시 재검토
+  F4. (반대방향 오류 감지) strict 1.5× 거래량 floor 에서만 차단된
+      no-handle 후보 중 이후 20%+ 상승 비율 — 과반 초과 시
+      보수 장치가 과도 판정 (완화 검토, 단 F1~F3 통과 전제)
+판정: F1~F3 중 어느 하나 발화 → 장치 강화(사이징 ×0.5 등) 1회 시도,
+      재발화 시 B로 회귀. F1~F3 무발화 + F4 발화 → grace band 복원 검토.
+표본: 최소 코호트 크기는 measurement-based 로 recall 감사 프레임에서 산정.
+```
+
+### 6.1 측정 규약 부록 (리뷰 차단⑤ 해소 — 원문 비수정, 조작화만)
+
+- **코호트 이중 정의**: ⓐ 체결 코호트 = `positions` 와 (symbol,
+  entry_date±1영업일) join(수동 기록 규약 — #47). ⓑ **신호 코호트** =
+  go_now 행 기준 OHLCV 가상 추적(진입가=신호일 종가) — 체결 0건 구간에도
+  F1~F3 을 신호 기준으로 병행 판정(주 판정은 체결 코호트, 신호 코호트는
+  체결 표본 부족 시 대체 + 항상 병행 보고).
+- **F1**: 스탑아웃 = 가상/실제 손절가(TRADE_STOP_INITIAL_PCT −8%) 터치,
+  창 = 진입 후 8주. **F2**: 창 = 진입 후 8주(F1 동일), "조기실패" = 종가
+  기준 pivot 하회 복귀 AND 최고 도달 < 진입가×1.05. **F3**: 실현손실 =
+  청산(실제 또는 신호 코호트는 8주 창 종료가) 손실률 절대값.
+- **F4**: 분모 = `wait_reason='volume_below_strict_no_handle'` **행 단위**
+  (동일 종목 복수 행 허용 — 차단 이벤트가 단위), 기준가 = 차단 당시
+  pivot, 창 = 차단 후 8주, "20%+ 상승" = 최고가 ≥ pivot×1.20.
+- **판정 시점**: 첫 판독 = 코호트 최소 크기 도달 시(recall 감사 프레임
+  — go_now ≥20 선례 #45). 그 전 관측치는 참고 보고만.
+
+## 7. 의존성 맵 (threshold-change-checklist — 상수별 행 2축 판정)
+
+**1단계(파생 신호)**: strict 인터셉트 → `wait_reason='volume_below_strict_no_handle'`
+행 / flag 주입 → `no_handle_shakeout_absent` → 사이징·경고 / 신 pattern 값 →
+분류·pivot_basis·트리거 경로 전파.
+
+**2단계(소비 룰)**: evaluate_pivot 인터셉트 체인(#45 extended → 신규 strict →
+dedupe) / entry_params_calc 티어·배수·vol_req / trigger_gate(발화 —
+GATE_BREAKOUT_VOL_MULT) / prompt §8.5 밴드·D4.
+
+**3단계(룰 내부 고정 상수) — 상수별 2축**:
+
+| 고정 상수 | 축1 환산? | 축2 영향? | 책 정합 | 판정 → 후속 |
+|---|---|---|---|---|
+| BREAKOUT_VOL_PREFERRED=1.5 (신규 소비: strict floor) | 가능(배수) | **있음** — 이 패턴의 유일 통과 기준이 됨. 1.5 는 기존 "선호" 값의 승격 재사용(신규 수치 아님) | PRESERVES(O'Neil 40~50%+ 서술의 시스템 최소치) | 값 불변·소비 추가 — F4 가 과도성 감시(B-수치 = F4 판독) |
+| BREAKOUT_VOL_FLOOR=1.4 / WAIT_FLOOR=1.2 | 가능 | **미미** — 이 패턴 한정 비적용(타 패턴 경로 불변). 비적용이 명시적 분기라 상호작용 없음 | EXTENDS | 모니터링(근거: 분기 조건이 pattern 등가 비교 단일 지점) |
+| GATE_BREAKOUT_VOL_MULT=1.0 (발화) | 가능 | **미미** — 발화 집합 불변, 발화 후 차단만 추가(#45 동형·보수화만) | EXTENDS | 모니터링(근거: 발화 임계 비접촉 — F4 분모가 발화 후 차단분을 전수 포착) |
+| PIVOT_EXTENDED_BAND_MULT=1.05 (#45 인터셉트) | 가능 | **있음** — 인터셉트 순서가 F4 분모를 결정(extended 선행 안 하면 코호트 오염) | EXTENDS | 순서 명문화(§3) + 테스트로 고정 |
+| HANDLE_LEGIT_MIN_DAYS=5 (Gate3 경계) | 불가(일수) | **있음** — with/without 분기점으로 역할 확장(구: watch 강등점). 5일 자체는 불변 | design-judgment(HMMS 예외 하한 채택 기존 태그) | 값 불변·역할 확장 — F1~F3 비교군 정의가 이 경계에 의존함을 §6.1 에 기록 |
+| CUP_NH_RECOVERY_MIN=0.90 (신설, 프롬프트 전용) | 가능(비율) | **있음** — base_forming↔신 패턴 경계. 0.95(§8.5 밴드)와 이중 경계 형성: 0.90~0.95 = watch 대기존 | design-judgment(핸들 깊이 12% 존과 정합) | **B-수치**: 재분류 flip-flop 률·경계 분포를 첫 판독에 동반(코드 비소비 — SSOT 비등재, #19 전례) |
+| `_FLAG_MULT` 0.7 (신설 값) | 가능 | **있음** — 실효 4.9pp 를 결정(티어 7.0 fallback 과 곱) | design-judgment(Minervini pilot 보수화 표 관례) | F1~F3 발화 시 ×0.5 강화 1회(사전등록 §6 판정 규칙이 후속을 이미 등록) |
+| `_SIZE_FALLBACK_STD`=7.0 (소비) | 가능 | **있음** — flag 주입이 이 티어를 상시 선택(standard 10.0 도달 불능 — dead code 사유로 _STANDARD_PATTERNS 비등재) | EXTENDS | 값 불변 — #80(이중 구조 전면 재검토)로 이관 |
+| TRADE_STOP_INITIAL_PCT=−8% (F1 측정 소비) | 가능 | **미미** — 측정 정의로만 소비(동작 비접촉) | PRESERVES(O'Neil 7~8%) | 모니터링(근거: 읽기 전용 소비) |
+
+**소비 경계(1줄)**: 주말 A 분류(pattern·pivot) → 평일 B(trigger_gate 발화 →
+evaluate_pivot 인터셉트 체인) → C(entry_params_calc 사이징) → go_now 신호 /
+positions(수동) — 신 패턴은 이 4층을 전부 통과하며, 각 층의 변경이 위 행들.
+
+## 8. 비변경·테스트·동기화
+
+- **비변경**: Gate2 V 배제, 발화 임계, 타 패턴 경로 전부, `handle_quality`
+  backstop(pattern≠cup_with_handle 자동 skip — 리뷰 확인), §6.1/§6.2 게이트.
+- **TDD 목록**: ① Gate3 분기(프롬프트 게이트 테스트 — tests/test_prompt_*
+  관례) ② strict 인터셉트(1.49 차단·1.5 통과·extended 선행 순서·타 패턴
+  비적용) ③ flag 주입 멱등+4.9pp 실효 ④ dedupe(상향 한정·invalidation
+  비억제) ⑤ pivot_basis cup_high +tick 사후검증 ⑥ vol_req 표기.
+- **수동 동기화 목록**(비차단 9): `verify_analysis_v1.md:12` 패턴 카운트,
+  analyze §Forbidden :678 "9→10-value", web `base-patterns.ts`·
+  `entry-params-fields.ts:35`(vol_req enum)·`stages.ts:270`. thresholds.py
+  변경 없음(신설 상수 0 — 프롬프트 전용값 원칙) → export 재실행 불요.
+- **F1~F4 배포**: 본 문서 §6 이 등록본. 구현 PR 머지 시점부터 코호트 발생.

--- a/kr_pipeline/llm_runner/compute/entry_params_calc.py
+++ b/kr_pipeline/llm_runner/compute/entry_params_calc.py
@@ -40,6 +40,10 @@ _SIZE_PP_WIDE_FLOOR = 3.0  # §7: wide_and_loose → 3.0 floor (pocket pivot)
 
 # §3.3 배수 (책 근거: Minervini pilot buy 보수화 — 구 프롬프트 §3.3 표)
 _FLAG_MULT = {
+    # (#74) cup_without_handle 결정론 주입 flag — shakeout 부재 보수화.
+    # 실효 = fallback 7.0 × 0.7 = 4.9pp (이중 페널티 수용 — 사용자 결정 07-24,
+    # 구조 재검토는 #80). specs/2026-07-24-issue74-cup-without-handle.md §4.
+    "no_handle_shakeout_absent": 0.7,
     "late_stage_base": 0.7,
     "narrow_base": 0.7,
     "thin_liquidity_us_only": 0.7,
@@ -51,6 +55,7 @@ _FLAG_MULT = {
     "reverse_split_distortion": 0.5,
 }
 _MULT_WARNING = {
+    "no_handle_shakeout_absent": "size_reduced_due_to_no_handle_shakeout",
     "late_stage_base": "size_reduced_due_to_late_stage",
     "thin_liquidity_us_only": "size_reduced_due_to_thin_liquidity",
     "unfavorable_market_context": "size_reduced_due_to_unfavorable_market",
@@ -67,6 +72,7 @@ _WARNING_PRIORITY = [
     "absolute_stop_used_due_to_wide_handle",
     "size_floored_due_to_multiple_flags",
     "size_reduced_due_to_unfavorable_market",
+    "size_reduced_due_to_no_handle_shakeout",
     "size_reduced_due_to_late_stage",
     "size_reduced_due_to_thin_liquidity",
     "breakout_volume_below_requirement",
@@ -112,6 +118,11 @@ def calculate_entry_params(payload: dict) -> dict:
     current = float(current)
 
     raw_flags = list(pa.get("risk_flags") or [])
+    # (#74) cup_without_handle → 결정론 flag 주입(멱등, LLM 재량 아님) — 티어
+    # no_flags 판정과 _FLAG_MULT 둘 다에 작용(이중 페널티 수용, 실효 4.9pp)
+    if pa.get("pattern") == "cup_without_handle" \
+            and "no_handle_shakeout_absent" not in raw_flags:
+        raw_flags.append("no_handle_shakeout_absent")
     # §7 breakout_from_watch 예외 — stale unfavorable 의 '완화 효과 4개(size×0.5 /
     # target cap / window=1 / stop 강화)'만 미적용 (#29/#34 로 전제 성립). 예외는
     # 열거된 효과에 한정: §3 티어 조건("no risk flags")과 chase=2.0 은 raw 기준 그대로 —
@@ -311,7 +322,10 @@ def calculate_entry_params(payload: dict) -> dict:
     if entry_mode == "pocket_pivot":
         vol_req = "pocket_pivot_signature"  # flag 산출이 signature 를 결정론 보증 — 재검증 없음
     else:
-        vol_req = "ge_1.5x_50day_avg"  # v2.1 기본. ge_1.3x 완화 분기는 폐기(완화 유령 제거)
+        # (#74) cup_without_handle 은 strict 표기 — 실제 차단은 B 인터셉트
+        # (evaluate_pivot)가 선행하므로 여기 도달분은 이미 ≥1.5x
+        vol_req = ("ge_1.5x_strict" if pattern == "cup_without_handle"
+                   else "ge_1.5x_50day_avg")  # 기본 v2.1. ge_1.3x 완화 분기는 폐기
         if ratio is not None:
             if ratio < BREAKOUT_VOL_FLOOR:
                 known.append("breakout_volume_below_requirement")

--- a/kr_pipeline/llm_runner/evaluate_pivot.py
+++ b/kr_pipeline/llm_runner/evaluate_pivot.py
@@ -9,12 +9,16 @@ from datetime import date, datetime, timezone
 
 from psycopg import Connection
 
-from kr_pipeline.common.thresholds import PIVOT_EXTENDED_BAND_MULT
+from kr_pipeline.common.thresholds import (
+    BREAKOUT_VOL_PREFERRED,
+    PIVOT_EXTENDED_BAND_MULT,
+)
 from kr_pipeline.llm_runner.compute.payload_lite import build_for_5b
 from kr_pipeline.llm_runner.compute.trigger_gate import evaluate as evaluate_gate
 from kr_pipeline.llm_runner.llm.claude_cli import call_claude, UsageLimitError
 from kr_pipeline.llm_runner.load import get_active_with_current
 from kr_pipeline.llm_runner.store import insert_trigger_log
+from kr_pipeline.trade_management.store import get_open_positions
 
 # (#45) 결정론 extended 게이트의 wait 사유 — 사전등록 코호트 질의 키(동등비교 전용).
 # weekly watch_reason='extended'(주 단위)와 별개 값(일 단위 경로) — 리네임 없음.
@@ -23,6 +27,14 @@ EXTENDED_WAIT_REASON = "extended_past_buy_range"
 # (#45) 인터셉트 대상 = go_now 로 이어질 수 있는 상향 트리거만.
 # promotion 은 §3.3 이 go_now 를 전면 금지(매수 위험 0), invalidation 은 하향 — 비대상.
 _EXTENDED_INTERCEPT_TRIGGERS = frozenset({"breakout", "breakout_from_watch"})
+
+# (#74) strict 1.5× 거래량 게이트 — cup_without_handle 전용(F4 사전등록 코호트 키).
+STRICT_NH_WAIT_REASON = "volume_below_strict_no_handle"
+
+# (#74) 보유 억제(dedupe) — 상향 트리거 전부. invalidation(하향)은 보유자 필수
+# 신호라 절대 비억제. 체인 순서 = dedupe → extended → strict (F4 분모 오염 방지).
+POSITION_SUPPRESSED_WAIT_REASON = "suppressed_position_held"
+_UPWARD_TRIGGERS = frozenset({"breakout", "breakout_from_watch", "promotion"})
 
 
 log = logging.getLogger("kr_pipeline.llm_runner.evaluate_pivot")
@@ -130,11 +142,28 @@ def run(
         len(triggered), len(active), abort_skipped,
     )
 
+    held = {p["symbol"] for p in get_open_positions(conn)}
+
     evaluated = 0
     extended_blocked = 0
+    strict_vol_blocked = 0
+    position_suppressed = 0
     failed = []
     for a, trig in triggered:
         try:
+            # (#74) 보유 억제 — 상향 트리거는 보유 중 재트리거가 전부 노이즈
+            # (단순 abort 모델·피라미딩 없음). invalidation 은 통과(하향 신호).
+            # 체인 최선행: 억제분이 extended/strict(F4 분모) 기록에 안 섞이게.
+            if trig in _UPWARD_TRIGGERS and a["symbol"] in held:
+                _record_deterministic_wait(
+                    conn, a, trig, dry_run=dry_run, as_of=as_of,
+                    wait_reason=POSITION_SUPPRESSED_WAIT_REASON,
+                    reasoning=("deterministic dedupe: open position held — "
+                               "upward re-trigger suppressed (#74 §5)"),
+                )
+                position_suppressed += 1
+                conn.commit()
+                continue
             # (#45) 결정론 extended 게이트 — O'Neil 5% 추격 금지의 매수 시점 강제.
             # close > pivot × 1.05 인 상향 트리거는 LLM 없이 wait 기록(결정 3′,
             # plans/2026-07-21-issue45-extended-gate.md §1). buy zone 복귀일에만
@@ -147,6 +176,27 @@ def run(
                 extended_blocked += 1
                 conn.commit()
                 continue
+            # (#74) strict 1.5× — cup_without_handle 은 grace band(1.2~1.4)·
+            # 1.4 floor 비허용. 결측(volume/avg)은 차단 근거로 쓰지 않음(LLM 경로).
+            # specs/2026-07-24-issue74-cup-without-handle.md §3.
+            if trig in _EXTENDED_INTERCEPT_TRIGGERS \
+                    and a.get("pattern") == "cup_without_handle":
+                vol, avg = a.get("volume"), a.get("avg_volume_50d")
+                if vol is not None and avg is not None and float(avg) > 0:
+                    ratio = float(vol) / float(avg)
+                    if ratio < BREAKOUT_VOL_PREFERRED:
+                        _record_deterministic_wait(
+                            conn, a, trig, dry_run=dry_run, as_of=as_of,
+                            wait_reason=STRICT_NH_WAIT_REASON,
+                            reasoning=(
+                                f"deterministic strict volume gate (#74): ratio "
+                                f"{ratio:.2f} < {BREAKOUT_VOL_PREFERRED} — "
+                                f"no-handle breakout requires strict 1.5x"
+                            ),
+                        )
+                        strict_vol_blocked += 1
+                        conn.commit()
+                        continue
             _process_one(conn, a, trig, dry_run=dry_run, as_of=as_of)
             evaluated += 1
             conn.commit()
@@ -170,41 +220,36 @@ def run(
         "triggered": len(triggered),
         "abort_skipped": abort_skipped,
         "extended_blocked": extended_blocked,
+        "strict_vol_blocked": strict_vol_blocked,
+        "position_suppressed": position_suppressed,
     }
 
 
-def _record_extended_block(conn, active_row, trig_type, *, dry_run, as_of):
-    """(#45) extended 차단의 결정론 wait 행 기록 — LLM 비관여(llm_* 전부 NULL).
+def _record_deterministic_wait(conn, active_row, trig_type, *, dry_run, as_of,
+                               wait_reason, reasoning):
+    """결정론 wait 행 기록 공통기 — LLM 비관여(llm_* 전부 NULL).
 
-    close/pivot 원값 보존 — pivot 재판독(±20% 실측) 시 "지난주 차단이 pivot
-    오독 때문이었는지" 사후 감사용. reasoning 은 사람용 산식 표시일 뿐,
-    조회 기준은 wait_reason 동등비교만(사전등록 규약).
+    close/pivot/volume 원값 보존 — 사후 감사·F4 측정 재료. reasoning 은
+    사람용 산식 표시일 뿐, 조회 기준은 wait_reason 동등비교만(사전등록 규약).
+    (#45 extended / #74 strict·dedupe 공용.)
     """
     symbol = active_row["symbol"]
-    close = active_row["close"]
-    pivot = active_row["pivot_price"]
-    extension_pct = (close / pivot - 1) * 100
     if dry_run:
-        log.info(
-            "dry-run: extended block %s (close %s > pivot %s × %s, %+.1f%%)",
-            symbol, close, pivot, PIVOT_EXTENDED_BAND_MULT, extension_pct,
-        )
+        log.info("dry-run: deterministic wait %s (%s) %s", symbol, wait_reason,
+                 reasoning)
         return
     insert_trigger_log(
         conn,
         symbol=symbol,
         evaluated_at=datetime.now(timezone.utc),
         trigger_type=trig_type,
-        close=close,
+        close=active_row["close"],
         volume=active_row["volume"],
-        pivot_price=pivot,
+        pivot_price=active_row["pivot_price"],
         result={
             "decision": "wait",
             "confidence": None,
-            "reasoning": (
-                f"deterministic extended gate: close {close} > pivot {pivot} × "
-                f"{PIVOT_EXTENDED_BAND_MULT} (extension {extension_pct:+.1f}%)"
-            ),
+            "reasoning": reasoning,
             "abort_reason": None,
         },
         # subscript 의도적 — prior_classification_at 은 NOT NULL 컬럼이고 production
@@ -213,7 +258,22 @@ def _record_extended_block(conn, active_row, trig_type, *, dry_run, as_of):
         prior_classification_at=active_row["classified_at"],
         llm_meta={},
         analyzed_for_date=as_of,
+        wait_reason=wait_reason,
+    )
+
+
+def _record_extended_block(conn, active_row, trig_type, *, dry_run, as_of):
+    """(#45) extended 차단 기록 — _record_deterministic_wait 로 위임."""
+    close = active_row["close"]
+    pivot = active_row["pivot_price"]
+    extension_pct = (close / pivot - 1) * 100
+    _record_deterministic_wait(
+        conn, active_row, trig_type, dry_run=dry_run, as_of=as_of,
         wait_reason=EXTENDED_WAIT_REASON,
+        reasoning=(
+            f"deterministic extended gate: close {close} > pivot {pivot} × "
+            f"{PIVOT_EXTENDED_BAND_MULT} (extension {extension_pct:+.1f}%)"
+        ),
     )
 
 

--- a/kr_pipeline/llm_runner/store.py
+++ b/kr_pipeline/llm_runner/store.py
@@ -204,7 +204,8 @@ def _pivot_continuity(
 # 이 성립하고 +0.1 오프셋 규칙이 적용되는 집합. pocket pivot 등 표 밖 basis 는
 # base_high 초과가 정당하므로 비대상 (HARD 미검사 사유와 동일 — docstring 참조).
 _PIVOT_TABLE_BASES = frozenset(
-    {"handle_high", "range_high", "final_T_high", "mid_W_peak"}
+    # cup_high = (#74) cup_without_handle 의 컵 절대 고점 pivot — +tick 검증 대상
+    {"handle_high", "range_high", "final_T_high", "mid_W_peak", "cup_high"}
 )
 
 

--- a/prompts/analyze_chart_v3.md
+++ b/prompts/analyze_chart_v3.md
@@ -138,6 +138,7 @@ Examine weekly OHLCV (104 weeks available) and the weekly chart image if provide
 |---|---|---|
 | `flat_base` | 5+ weeks sideways; ≤15% correction from high to low; prior uptrend ≥20% from previous base | O'Neil, *HMMS* Ch.2 (수치 원전; 구 Minervini 표기는 오귀속 — 2026-07-22 정정) |
 | `cup_with_handle` | U-shape (not V); 7–45 weeks; depth ≤33% (up to 50% if forming during/after bear market recovery, per O'Neil); handle forms in upper half of cup on lower volume; handle ≥1 week | O'Neil *HMMS* Ch.2 7–65w / Minervini *TLSMW* Ch.10 3–45w — 시스템 교집합 7–45w (design judgment) |
+| `cup_without_handle` | 컵 기준은 cup_with_handle 과 **완전 동일**(U-shape not V; 7–45w; depth ≤33%/베어 회복 50%; 선행상승 ≥30%) — 핸들 요소만 없음. **우측 회복 완료** 필요: 컵 바닥 이후 우측 구간의 **최고 종가 ≥ cup high × 0.90** (도달치 기준 래칫 — 한번 완성이면 이후 조정으로 밀려도 완성 유지, 현재가 위치는 §8.5 밴드가 담당) + U자 바닥 rounding 완성. pivot = **컵 내 절대 고점**(§4.7). 진입 규율: 돌파 거래량 strict 1.5×(§8 각주·B 게이트) + 사이징 감액(shakeout 부재 보수화 — C 단계 자동) | O'Neil *HMMS* 5대 모델 장 — cup-without-handle 명명·승자 사례 실재 (book-mandated). 0.90 회복 경계·보수 장치는 design judgment (#74) |
 | `vcp` | Successive price contractions (each tighter, typically ~half the prior); volume contracting with each contraction; 2–6 contractions (typically 2–4) | Minervini, *TLSMW* Ch.10 |
 | `double_bottom` | Two lows near the same level; second undercuts first (W-shape, shakeout); 7+ weeks total duration; pivot at middle peak of W | O'Neil, *HMMS* Ch.2 |
 | `none` | No structure matching above. Use for climax runs, early-stage, wide-and-loose action, or ambiguous structure. |
@@ -162,14 +163,21 @@ Examine weekly OHLCV (104 weeks available) and the weekly chart image if provide
 
 **★ 경계 수렴 규칙 (verdict 재현 — over-forcing 아닌 over-rejecting 방지)**: `prior_uptrend`·`cup_depth` 가 밴드 내(전제 통과)인데 U/V·climax 판정이 *애매한* 종목은 — **명백한 실격(명백 climax / 명백 직하강 V / depth ≫ 상한)이 아닌 한** — `not_cup_family`/`gate2` 로 튀어 `ignore` 가 되지 말고, **형성중·불명확 base = 보수적 `watch`** 로 수렴하라(cup 으로 보아 Gate3 진행). 책: 형성중·불명확 base 는 *매수 보류*(watch)이지 *배제*(ignore)가 아니다. `ignore` 는 명백 실격에만. (목표는 라벨 고정이 아니라 *verdict 재현* — 같은 경계 종목이 회차마다 watch↔ignore 로 갈리면 안 된다.)
 - **Gate3 (핸들 — 분기, shape ≠ quality 분리; 길이 먼저)**:
-  - **핸들 길이 < HANDLE_LEGIT_MIN_DAYS(5거래일 ≈1주)** → `pattern=cup_with_handle`,
-    `handle_status=not_formed`, **classification=watch**. (2~3일 조임 = shakeout 미완 = *형성중* 이지
-    결함 아님 — faulty 로 보지 말 것. ~1주 floor 의 출처: O'Neil HMMS Ch.2 —
-    일반 규칙은 "more than one or two weeks", 1~2주는 변동성 큰 종목의 예외 하한.
-    시스템은 그 예외 하한을 floor 로 채택 [design judgment — 2026-07-22 책 검토:
-    Minervini 원문에 핸들 최소 기간 명시 문구 미확인, 구 'Minervini primary' 귀속 정정].)
-  - 핸들 미형성(cup 구조 완성, 핸들 아직) → `handle_status=not_formed`, **watch** (none 아님 —
-    '매수점 없음'은 verdict 판단이지 shape 판단 아님).
+  - **핸들 길이 < HANDLE_LEGIT_MIN_DAYS(5거래일 ≈1주) — 0일(핸들 시도 없음) 포함**
+    (2~3일 조임 = shakeout 미완 = *형성중* 이지 결함 아님 — faulty 로 보지 말 것.
+    ~1주 floor 의 출처: O'Neil HMMS Ch.2 — 일반 규칙은 "more than one or two
+    weeks", 1~2주는 변동성 큰 종목의 예외 하한을 floor 로 채택 [design
+    judgment — 2026-07-22 책 검토, 구 'Minervini primary' 귀속 정정].)
+    이때 컵 우측 회복 여부로 분기(#74):
+    - **우측 회복 완료**(컵 바닥 이후 최고 종가 ≥ cup high × 0.90 — 도달치
+      기준 래칫, §4 표) → `pattern=cup_without_handle`,
+      `handle_status=not_formed`, pivot = 컵 내 절대 고점(§4.7).
+      classification 은 §8.5 가격 밴드 그대로(pivot 확정 상태 — <0.95×pivot
+      은 watch `valid_base_awaiting_breakout`, 0.95~1.05 는 entry 후보).
+    - **우측 회복 미완**(최고 종가 < cup high × 0.90) →
+      `pattern=cup_with_handle`, `handle_status=not_formed`,
+      **classification=watch** (`base_forming` — 컵 우측 벽 미완 = base
+      미완성. 구 라벨 연속성 유지).
   - 적법 핸들(길이 ≥5일 ∧ 상단절반 ∧ 50일선 위 ∧ **하향(down) drift = shakeout** ∧ 깊이 ≤HANDLE_DEPTH_BULL_MAX_PCT(12%)) →
     `handle_status=legitimate` (entry 후보).
   - faulty 핸들(깊이 > HANDLE_DEPTH_BULL_MAX_PCT(12%) / 하단절반(handle_position=lower_half, 50% 경계) /
@@ -219,6 +227,10 @@ A pocket pivot is an early entry signal within an existing base, defined by Mora
 
 If `indicators_recent_60d[-5:].any(pocket_pivot_flag == true)` (pocket pivot triggered in past 5 sessions), evaluate as an alternate entry route:
 
+(**의도적 제외 — #74**: `cup_without_handle` 은 pocket pivot 대체 진입 **비대상**.
+PP 경로로 strict 1.5× 돌파 거래량 요건을 우회할 수 없다 — 후속 작업에서
+무심코 추가하지 말 것.)
+
 **Required criteria for valid pocket pivot:**
 - Stock is in Stage 2 (per §3) with a proper base of ≥ 6 weeks
   [**this ≥6-week floor is a hard requirement of THIS system — do not waive it.**
@@ -255,6 +267,7 @@ Boolean signals (use as corroboration, not as filters): `rs_line_at_52w_high` (R
 |-----------------|-----------------------------------|-----------------|
 | flat_base       | range_high + 0.1                  | range_high      |
 | cup_with_handle | handle_high + 0.1                 | handle_high     |
+| cup_without_handle | cup 내 절대 고점 + 0.1 (#74)    | cup_high        |
 | vcp             | final_T_high + 0.1                | final_T_high    |
 | double_bottom   | mid_W_peak + 0.1 (두 low 사이 최고점) | mid_W_peak        |
 | high_tight_flag | top of flag (highest point of consolidation)  | top_of_flag       |
@@ -509,6 +522,7 @@ If a base pattern is identified and you claim a pivot or breakout:
 
 - **pivot_price** = max(weekly.high) of the identified base period + $0.10 (Minervini's standard add-on). For KR stocks, use base high + 1 tick (typically +10 or +100 KRW depending on price level — but base_high alone is acceptable).
 - For `cup_with_handle`: pivot_price = high of the handle, not high of the cup.
+- For `cup_without_handle`: pivot_price = high of the cup (핸들이 없으므로 컵 절대 고점 — §4.7, #74).
 - For `double_bottom`: pivot_price = middle peak of the W (high between the two bottoms).
 - **breakout_date** = first trading day in daily data where `close > pivot_price` on volume ≥ 1.4× 50-day average.
 - If you claim a breakout but no day in the provided daily data shows `close > pivot_price`: this is a methodology error. Lower confidence by 0.2 and note the discrepancy in `reasoning`, and DO NOT classify as `entry` based on a non-existent breakout.
@@ -519,6 +533,9 @@ If a base pattern is identified and you claim a pivot or breakout:
 - **돌파 거래량 확인 (verdict 필수 입력 — 분해로 누락 금지)**: entry 는 돌파 거래량 ≥ 50일 평균 1.4~1.5×
   (O'Neil/Minervini). 미달 → `low_volume_breakout` → entry 아닌 watch. ⚠ `measurements.handle_volume_ratio`
   (핸들 dry-up = 품질)와 *별개* — 혼동 금지.
+  **cup_without_handle 각주(#74)**: **돌파를 근거로 entry 판정할 때에 한해** strict **1.5×** 미만이면
+  entry 로 판정하지 말 것(1.4~1.5 grace 비허용 — shakeout 부재 보수 장치). 돌파 전 밴드 내(§8.5
+  0.95~1.05) entry 는 이 각주 비적용(거래량 조건 없음 — 밴드 규칙 그대로).
 
 Synthesize Steps 1–7 into `entry / watch / ignore`:
 
@@ -537,7 +554,7 @@ LLM 정밀판정으로 넘길지(`breakout_from_watch`) 여부를 가른다.
 
 | watch_reason | 판정 기준 |
 |---|---|
-| `base_forming` | **pivot 정의 요소 미완성** → pivot 미확정. 예: **cup 구조 완성이나 handle 미형성**(handle 은 base 상반부 최종 구성요소 — handle 미형성 = pivot=handle_high 미정 = base 미완성, O'Neil HMM), VCP 최종 수축(final-T) 미완, flat base 옆걸음 확장 중, double_bottom 중앙 peak 미확정. *handle shakeout 전 성급한 돌파를 actionable 로 잡지 않기 위함.* |
+| `base_forming` | **pivot 정의 요소 미완성** → pivot 미확정. 예: **cup 우측 회복 미완**(컵 바닥 이후 최고 종가 < cup high × 0.90 — 우측 벽 미완 = base 미완성. 회복 완료 + 핸들 <5일이면 `cup_without_handle` 로 pivot 확정 — §4 Gate3, #74), VCP 최종 수축(final-T) 미완, flat base 옆걸음 확장 중, double_bottom 중앙 peak 미확정. *shakeout 부재 리스크는 배제가 아니라 보수 장치(§8 각주 strict 1.5×·C 단계 사이징 감액)로 흡수한다.* |
 | `extended` | pivot 정의 요소는 완성이나 current 가 이미 진입 구간 위로 extended(돌파 후 추격 구간 / `extended_from_ma`). |
 | `unfavorable_market` | 종목 셋업은 entry 급이나 §3.5 시장 방향(downtrend/correction/미확인 rally_attempt 또는 dist≥5)이 entry 를 watch 로 강등시킴. |
 | `marginal_tt` | Trend Template 통과가 marginal(§2: 3개 이상 조건이 <3% 마진) — 추가 확인 필요. |
@@ -581,13 +598,13 @@ Return ONLY valid JSON matching this schema. No prose, no markdown, no explanati
 {
   "classification": "entry | watch | ignore",
   "watch_reason": "base_forming | extended | unfavorable_market | marginal_tt | valid_base_awaiting_breakout | suspected_climax_stage_indeterminate | null",
-  "pattern": "flat_base | cup_with_handle | vcp | double_bottom | high_tight_flag | 3c_cheat | base_on_base | ascending_base | none",
+  "pattern": "flat_base | cup_with_handle | cup_without_handle | vcp | double_bottom | high_tight_flag | 3c_cheat | base_on_base | ascending_base | none",
   "confidence": 0.0,
   "reasoning": "≤1500자 (markdown, 5 sections)",
   "risk_flags": ["..."],
 
   "pivot_price": 82500.1,
-  "pivot_basis": "handle_high | range_high | final_T_high | mid_W_peak | null",
+  "pivot_basis": "handle_high | cup_high | range_high | final_T_high | mid_W_peak | null",
   "base_high": 82500.0,
   "base_low": 75000.0,
   "base_depth_pct": 9.1,
@@ -657,7 +674,7 @@ For non-VCP patterns (`flat_base`, `cup_with_handle`, etc.), both fields MUST be
   - 각 판단의 책 원전 (예: "Minervini Trend Template #5", "O'Neil HMM 'Cup with Handle'") 짧게 언급.
   - If pocket pivot entry, mark it explicitly in '진입 시그널'.
   - If 3-C / cheat early entry, mark it explicitly in '진입 시그널' or '결론'.
-- `pattern`: must be exactly one of: `flat_base`, `cup_with_handle`, `vcp`, `double_bottom`, `high_tight_flag`, `3c_cheat`, `base_on_base`, `ascending_base`, `none`.
+- `pattern`: must be exactly one of: `flat_base`, `cup_with_handle`, `cup_without_handle`, `vcp`, `double_bottom`, `high_tight_flag`, `3c_cheat`, `base_on_base`, `ascending_base`, `none`.
 - `watch_reason`: `classification == "watch"` 이면 §8.5 의 6개 enum 중 정확히 하나 (null 금지). `classification != "watch"`(entry/ignore) 이면 반드시 `null`. 제외 사유 우선(D4): base_forming/extended 가 해당하면 그것을 선택. `suspected_climax_stage_indeterminate` 는 §6.1 제3안(E1 판정 불능) 전용 — `trigger_gate.ALLOWED_WATCH_REASONS` 비포함이라 `breakout_from_watch` 재트리거 대상이 아니다(§8.5 표 참조).
 - `measurements`: **`prior_uptrend_pct` · `cup_depth_pct` · `cup_shape` 는 항상 보고** (어떤 차트든 측정 가능 — 이것이 트리 분기와 `none` 판정의 근거다; null 금지). `handle_*` 필드만 핸들 없음/비-cup 일 때 null. 숫자는 차트/OHLCV 에서 측정해 보고 — *라벨을 먼저 정하지 말고 측정값을 먼저 보고*.
 - `measurements.rejected_gate`: `pattern == "none"` 이면 **어느 Gate 에서 탈락했는지 의무 보고** — `gate0`(선행상승<30%) / `gate1`(depth 초과) / `gate2`(V자) / `not_cup_family`(climax·base 없음 등 cup 계열 1차 라우팅 미진입). cup 패턴이 식별되면(none 아님) `null`. (숫자만 채우고 분기를 안 적으면 "왜 none"이 비감사로 남으므로 필수.)
@@ -675,7 +692,7 @@ For non-VCP patterns (`flat_base`, `cup_with_handle`, etc.), both fields MUST be
 - Do not give entry parameters here (stop loss, position size) — that is a separate task (`calculate_entry_params`). pivot_price and base fields ARE output by this prompt (§4.7).
 - Do not include Trend Template positive signals (high RS Rating, price above MAs, MA alignment, RS Line leadership) as risk_flags.
 - Do not invent risk flags outside the 14-value taxonomy.
-- Do not invent new pattern names outside the 9-value taxonomy.
+- Do not invent new pattern names outside the 10-value taxonomy.
 - Do not classify as `entry` when `market_context.current_status` is downtrend/correction/unconfirmed_rally — this is a hard rule per §3.5.
 
 ## Input Payload

--- a/prompts/verify_analysis_v1.md
+++ b/prompts/verify_analysis_v1.md
@@ -9,7 +9,7 @@
 입력으로 제공된 `analysis_result.json` 의 다음 7 필드:
 - `measurements` (prior_uptrend_pct · cup_depth_pct · cup_shape · handle_status · handle_position · handle_vs_sma50 · handle_drift · handle_depth_pct · handle_volume_ratio 등 수치/enum 측정값)
 - `classification` (entry / watch / ignore)
-- `pattern` (9 base 패턴 중 하나 또는 none)
+- `pattern` (10 base 패턴 중 하나 또는 none)
 - `pivot_price` + `pivot_basis`
 - `base_depth_pct` + `base_high` + `base_low`
 - `risk_flags` (14 risk taxonomy 부분집합)

--- a/scripts/remeasure_phase2i.py
+++ b/scripts/remeasure_phase2i.py
@@ -1,4 +1,6 @@
 """Phase 2 (i) build-first 재측정 하니스 (spec §10 / plan Task 11).
+# ⚠ superseded (#74, 2026-07-24): Gate3 가 cup_without_handle 분기를 신설해
+#   아래 gate3_neg 합격 기대문(cup_with_handle 고정)은 구 기준 — 재사용 시 갱신 필요.
 
 ⚠ 일회성 *진단* 스크립트 — 프로덕션 경로 아님. DB 미기록, cron/파이프라인 미연결.
    프로덕션 분류는 kr_pipeline/llm_runner/ (weekend.py 등) 경로. 본 스크립트는 (i) 안정화

--- a/tests/test_entry_params_calc.py
+++ b/tests/test_entry_params_calc.py
@@ -300,3 +300,39 @@ def test_warnings_never_silently_truncated():
     assert len(r["known_warnings"]) == 8
     assert "extended_from_pivot_already" in r["known_warnings"]
     assert "stop_distance_from_current_price_exceeds_book_limit" in r["known_warnings"]
+
+
+# ---------- (#74) cup_without_handle 보수 장치 ----------
+
+def test_no_handle_flag_injected_and_sized_4_9pp():
+    """pattern=cup_without_handle → flag 결정론 주입: fallback 7.0 × 0.7 = 4.9pp.
+
+    준거: specs/2026-07-24-issue74-cup-without-handle.md §4 (이중 페널티 수용,
+    실효 4.9 — _STANDARD_PATTERNS 비등재는 dead code 사유).
+    """
+    r = calculate_entry_params(_payload(prior_analysis={
+        "pattern": "cup_without_handle", "pivot_basis": "cup_high"}))
+    assert r["suggested_weight_pct"] == 4.9
+    assert "size_reduced_due_to_no_handle_shakeout" in r["known_warnings"]
+    assert r["breakout_volume_requirement"] == "ge_1.5x_strict"
+
+
+def test_no_handle_flag_injection_idempotent():
+    """flag 가 이미 있어도(재실행·수동 포함) 배수 1회만 — 멱등."""
+    r = calculate_entry_params(_payload(prior_analysis={
+        "pattern": "cup_without_handle", "pivot_basis": "cup_high",
+        "risk_flags": ["no_handle_shakeout_absent"]}))
+    assert r["suggested_weight_pct"] == 4.9
+
+
+def test_no_handle_other_patterns_untouched():
+    """타 패턴엔 flag 미주입 — 기존 vol_req·티어 불변."""
+    r = calculate_entry_params(_payload())
+    assert r["breakout_volume_requirement"] == "ge_1.5x_50day_avg"
+    assert r["suggested_weight_pct"] == 10.0
+
+
+def test_cup_high_pivot_basis_in_store_tick_validation():
+    """pivot_basis='cup_high' 가 store +tick 사후검증 대상에 등재 (#74 §2)."""
+    from kr_pipeline.llm_runner.store import _PIVOT_TABLE_BASES
+    assert "cup_high" in _PIVOT_TABLE_BASES

--- a/tests/test_no_handle_gates.py
+++ b/tests/test_no_handle_gates.py
@@ -1,0 +1,167 @@
+# tests/test_no_handle_gates.py
+# (#74) cup_without_handle 보수 장치 — strict 1.5× 인터셉트 + 보유 억제(dedupe).
+# 준거: docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md §3·§5
+# 체인 순서 = dedupe → extended(#45) → strict (F4 분모 오염 방지).
+from datetime import date, datetime, timezone
+
+import pytest
+
+
+def _active_row(symbol, *, close, pivot=80.0, classification="entry",
+                prev_close=79.0, watch_reason=None, pattern="cup_without_handle",
+                volume=1_490_000, avg=1_000_000.0):
+    return {
+        "symbol": symbol, "close": close, "pivot_price": pivot,
+        "volume": volume, "avg_volume_50d": avg,
+        "stop_loss": 70.0, "sma_50": 78.0, "classification": classification,
+        "prev_close": prev_close, "watch_reason": watch_reason,
+        "pattern": pattern,
+        "classified_at": datetime(2026, 7, 24, 3, tzinfo=timezone.utc),
+    }
+
+
+def _run_with(db, mocker, active, *, held=frozenset()):
+    import kr_pipeline.llm_runner.evaluate_pivot as ev
+    mocker.patch.object(ev, "get_active_with_current", return_value=active)
+    mocker.patch.object(ev, "get_open_positions",
+                        return_value=[{"symbol": s} for s in sorted(held)])
+    llm_calls = []
+    mocker.patch.object(
+        ev, "_process_one",
+        side_effect=lambda conn, a, trig, *, dry_run, as_of: llm_calls.append((a["symbol"], trig)),
+    )
+    result = ev.run(db, dry_run=False, as_of=date(2026, 7, 24))
+    return result, llm_calls
+
+
+def _cleanup(db, *symbols):
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM trigger_evaluation_log WHERE symbol = ANY(%s)",
+                    (list(symbols),))
+    db.commit()
+
+
+def _log_row(db, symbol):
+    with db.cursor() as cur:
+        cur.execute("SELECT decision, wait_reason, trigger_type, llm_model "
+                    "FROM trigger_evaluation_log WHERE symbol=%s", (symbol,))
+        return cur.fetchone()
+
+
+# ---------- strict 1.5× ----------
+
+def test_strict_blocks_no_handle_below_1_5x(db, mocker):
+    """cup_without_handle + breakout + ratio 1.49 → LLM 미호출·결정론 wait."""
+    _cleanup(db, "NH1")
+    try:
+        result, llm_calls = _run_with(db, mocker, [_active_row("NH1", close=83.0)])
+        assert llm_calls == []
+        assert result.get("strict_vol_blocked") == 1
+        row = _log_row(db, "NH1")
+        assert row is not None, "결정론 wait 행 미기록"
+        assert row[0] == "wait" and row[1] == "volume_below_strict_no_handle"
+        assert row[2] == "breakout" and row[3] is None
+    finally:
+        _cleanup(db, "NH1")
+
+
+def test_strict_passes_at_exactly_1_5x(db, mocker):
+    """ratio 1.5 정확히 = 통과(< 1.5 만 차단) → LLM 경로."""
+    _cleanup(db, "NH2")
+    result, llm_calls = _run_with(
+        db, mocker, [_active_row("NH2", close=83.0, volume=1_500_000)])
+    assert llm_calls == [("NH2", "breakout")]
+    assert result.get("strict_vol_blocked", 0) == 0
+    assert _log_row(db, "NH2") is None
+
+
+def test_strict_not_applied_to_other_patterns(db, mocker):
+    """cup_with_handle ratio 1.49 → 기존 경로(grace band 유지) — 비적용."""
+    result, llm_calls = _run_with(
+        db, mocker, [_active_row("NH3", close=83.0, pattern="cup_with_handle")])
+    assert llm_calls == [("NH3", "breakout")]
+    assert result.get("strict_vol_blocked", 0) == 0
+
+
+def test_strict_unreachable_when_volume_data_missing(db, mocker):
+    """avg_volume_50d 결측 → 발화 자체 없음(게이트가 volume≥avg 요구) —
+    strict 인터셉트에 결측이 도달하는 경로가 없음을 고정(방어 분기는 belt).
+    """
+    result, llm_calls = _run_with(
+        db, mocker, [_active_row("NH4", close=83.0, avg=None)])
+    assert llm_calls == []
+    assert result.get("strict_vol_blocked", 0) == 0
+    assert _log_row(db, "NH4") is None
+
+
+def test_extended_precedes_strict(db, mocker):
+    """close 88(>1.05×80) + ratio 1.49 → extended 기록(strict 아님) — F4 오염 방지."""
+    _cleanup(db, "NH5")
+    try:
+        result, llm_calls = _run_with(db, mocker, [_active_row("NH5", close=88.0)])
+        assert llm_calls == []
+        assert result.get("extended_blocked") == 1
+        assert result.get("strict_vol_blocked", 0) == 0
+        assert _log_row(db, "NH5")[1] == "extended_past_buy_range"
+    finally:
+        _cleanup(db, "NH5")
+
+
+# ---------- dedupe (보유 억제) ----------
+
+def test_held_symbol_upward_trigger_suppressed(db, mocker):
+    """보유 티커의 breakout → 억제 행 기록 + LLM 미호출."""
+    _cleanup(db, "NH6")
+    try:
+        result, llm_calls = _run_with(
+            db, mocker, [_active_row("NH6", close=83.0, volume=2_000_000)],
+            held={"NH6"})
+        assert llm_calls == []
+        assert result.get("position_suppressed") == 1
+        row = _log_row(db, "NH6")
+        assert row[0] == "wait" and row[1] == "suppressed_position_held"
+    finally:
+        _cleanup(db, "NH6")
+
+
+def test_held_symbol_breakout_from_watch_and_promotion_suppressed(db, mocker):
+    """상향 3종 전부 억제 — breakout_from_watch·promotion."""
+    _cleanup(db, "NH7", "NH8")
+    try:
+        rows = [
+            _active_row("NH7", close=83.0, classification="watch",
+                        prev_close=79.0, watch_reason="valid_base_awaiting_breakout",
+                        volume=2_000_000),
+            _active_row("NH8", close=88.0, classification="watch",
+                        prev_close=85.0, watch_reason="unfavorable_market",
+                        pattern="flat_base", volume=2_000_000),
+        ]
+        result, llm_calls = _run_with(db, mocker, rows, held={"NH7", "NH8"})
+        assert llm_calls == []
+        assert result.get("position_suppressed") == 2
+    finally:
+        _cleanup(db, "NH7", "NH8")
+
+
+def test_held_symbol_invalidation_not_suppressed(db, mocker):
+    """보유 티커의 invalidation(손절 신호)은 절대 억제 안 함 → LLM 경로."""
+    row = _active_row("NH9", close=69.0, classification="entry",
+                      prev_close=71.0, pattern="flat_base", volume=2_000_000)
+    result, llm_calls = _run_with(db, mocker, [row], held={"NH9"})
+    assert llm_calls == [("NH9", "invalidation")]
+    assert result.get("position_suppressed", 0) == 0
+
+
+def test_dedupe_precedes_extended(db, mocker):
+    """보유 + close 88(extended 구간) → 억제 기록(extended 아님) — 체인 최선행."""
+    _cleanup(db, "NHA")
+    try:
+        result, llm_calls = _run_with(
+            db, mocker, [_active_row("NHA", close=88.0, volume=2_000_000)],
+            held={"NHA"})
+        assert llm_calls == []
+        assert result.get("position_suppressed") == 1
+        assert result.get("extended_blocked", 0) == 0
+        assert _log_row(db, "NHA")[1] == "suppressed_position_held"
+    finally:
+        _cleanup(db, "NHA")

--- a/tests/test_no_handle_gates.py
+++ b/tests/test_no_handle_gates.py
@@ -139,6 +139,10 @@ def test_held_symbol_breakout_from_watch_and_promotion_suppressed(db, mocker):
         result, llm_calls = _run_with(db, mocker, rows, held={"NH7", "NH8"})
         assert llm_calls == []
         assert result.get("position_suppressed") == 2
+        # 발화 유형 고정 — NH7=breakout_from_watch(fresh cross), NH8=promotion
+        # (회귀로 둘 다 bfw 로 변질되는 것 방지, 최종 리뷰 권고 5)
+        assert _log_row(db, "NH7")[2] == "breakout_from_watch"
+        assert _log_row(db, "NH8")[2] == "promotion"
     finally:
         _cleanup(db, "NH7", "NH8")
 

--- a/tests/test_prompt_no_handle.py
+++ b/tests/test_prompt_no_handle.py
@@ -1,0 +1,49 @@
+# tests/test_prompt_no_handle.py
+# (#74) cup_without_handle 프롬프트 텍스트 고정 — 드리프트 방지.
+# 한계: LLM 행동 검증은 재실행 비교 금지 규율상 불가 — 텍스트 검증까지(스펙 §8).
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_ANALYZE = (_ROOT / "prompts" / "analyze_chart_v3.md").read_text()
+_VERIFY = (_ROOT / "prompts" / "verify_analysis_v1.md").read_text()
+
+
+def test_pattern_enum_contains_cup_without_handle():
+    """§8.6 스키마 enum + §9 검증 목록 양쪽에 신 패턴 존재."""
+    assert _ANALYZE.count("cup_without_handle") >= 6
+    assert ("flat_base | cup_with_handle | cup_without_handle | vcp" in _ANALYZE), \
+        "§8.6 pattern enum 누락"
+    assert "`cup_with_handle`, `cup_without_handle`, `vcp`" in _ANALYZE, \
+        "§9 검증 목록 누락"
+    assert "10-value taxonomy" in _ANALYZE and "9-value taxonomy" not in _ANALYZE
+
+
+def test_pivot_rules_cup_high():
+    """§4.7 표 행 + pivot_basis enum + §7 대비 문장."""
+    assert "| cup_without_handle | cup 내 절대 고점 + 0.1" in _ANALYZE
+    assert "handle_high | cup_high | range_high" in _ANALYZE, "pivot_basis enum 누락"
+    assert "pivot_price = high of the cup" in _ANALYZE, "§7 대비 문장 누락"
+
+
+def test_gate3_recovery_boundary_and_base_forming_rewrite():
+    """Gate3 0.90 래칫 분기 + §8.5 base_forming 재작성(구 문장 제거)."""
+    assert "cup high × 0.90" in _ANALYZE
+    assert "도달치" in _ANALYZE  # 래칫(도달치 기준) 명시
+    assert "cup 우측 회복 미완" in _ANALYZE, ":540 재작성 누락"
+    assert "handle shakeout 전 성급한 돌파" not in _ANALYZE, "구 근거 문장 잔존"
+
+
+def test_strict_volume_footnote_scoped_to_breakout():
+    """§8 각주 — '돌파를 근거로 entry 판정할 때에 한해' 스코프 한정."""
+    assert "cup_without_handle 각주(#74)" in _ANALYZE
+    assert "돌파를 근거로 entry 판정할 때에 한해" in _ANALYZE
+    assert "strict **1.5×**" in _ANALYZE
+
+
+def test_pocket_pivot_exclusion_explicit():
+    """§4.5 — PP 경로로 strict 우회 불가 명기(의도적 제외)."""
+    assert "pocket pivot 대체 진입 **비대상**" in _ANALYZE
+
+
+def test_verify_prompt_pattern_count():
+    assert "10 base 패턴" in _VERIFY and "9 base 패턴" not in _VERIFY

--- a/web/src/data/llm-pipeline-audit/base-patterns.ts
+++ b/web/src/data/llm-pipeline-audit/base-patterns.ts
@@ -20,6 +20,12 @@ export const BASE_PATTERNS: BasePattern[] = [
     source: "O'Neil, *HMMS* Ch.2",
   },
   {
+    id: "cup_without_handle",
+    definition:
+      "컵 기준은 cup_with_handle 과 동일(U-shape not V; 7–45 weeks; depth ≤33%/베어 회복 50%) — 핸들 없음. 우측 회복(최고 종가 ≥ cup high × 0.90, 래칫) 필요. 돌파 strict 1.5× + 사이징 감액(#74 보수 장치)",
+    source: "O'Neil, *HMMS* 5대 모델 장 (book-mandated) — 경계·장치는 design judgment #74",
+  },
+  {
     id: "vcp",
     definition:
       "Successive price contractions (each tighter, typically ~half the prior); volume contracting with each contraction; 2–6 contractions (typically 2–4)",
@@ -66,6 +72,7 @@ export const BASE_PATTERNS: BasePattern[] = [
 export const NARROW_BASE_THRESHOLDS = [
   { pattern: "flat_base", minWeeks: 5 },
   { pattern: "cup_with_handle", minWeeks: 7 },
+  { pattern: "cup_without_handle", minWeeks: 7 },
   { pattern: "double_bottom", minWeeks: 7 },
   { pattern: "vcp", minWeeks: 5 },
 ];
@@ -85,6 +92,7 @@ export interface PivotRule {
 export const PIVOT_RULES: PivotRule[] = [
   { pattern: "flat_base", formula: "range_high + 0.1", basisLabel: "range_high" },
   { pattern: "cup_with_handle", formula: "handle_high + 0.1", basisLabel: "handle_high" },
+  { pattern: "cup_without_handle", formula: "cup 내 절대 고점 + 0.1", basisLabel: "cup_high" },
   { pattern: "vcp", formula: "final_T_high + 0.1", basisLabel: "final_T_high" },
   { pattern: "double_bottom", formula: "mid_W_peak + 0.1 (두 low 사이 최고점)", basisLabel: "mid_W_peak" },
   { pattern: "high_tight_flag", formula: "top of flag (consolidation 최고점)", basisLabel: "top_of_flag" },

--- a/web/src/data/llm-pipeline-audit/stages.ts
+++ b/web/src/data/llm-pipeline-audit/stages.ts
@@ -267,7 +267,7 @@ position_size_pct (prompt §3.1-3.3):
 10. risk_reward_ratio
 11. position_size_pct (3-25%)
 12. position_size_basis
-13. breakout_volume_requirement (ge_1.3x / 1.4x / 1.5x_50day_avg / pocket_pivot_signature)
+13. breakout_volume_requirement (ge_1.3x / 1.4x / 1.5x_50day_avg / 1.5x_strict(#74) / pocket_pivot_signature)
 14. observed_breakout_volume_ratio
 15. known_warnings (JSONB 15 화이트리스트)
 16. other_warnings

--- a/web/src/data/llm-pipeline/entry-params-fields.ts
+++ b/web/src/data/llm-pipeline/entry-params-fields.ts
@@ -29,10 +29,10 @@ export const ENTRY_PARAMS_FIELDS: EntryParamField[] = [
   { name: "suggested_weight_pct", category: "sizing", what: "포트폴리오 내 권장 비중 % — Minervini 의 거래당 1-3% 위험 룰 적용.", constraint: "3.0 ~ 25.0%" },
 
   // Guard 매수 가드 + 거래량 요건 (5, 모두 category: "guard")
-  { name: "pattern_basis", category: "guard", what: "이 매수가 어떤 base 패턴에 기반했는지 (flat_base / cup_with_handle / vcp / double_bottom / 3c_cheat).", constraint: "exactly one of: flat_base, cup_with_handle, vcp, double_bottom, 3c_cheat" },
+  { name: "pattern_basis", category: "guard", what: "이 매수가 어떤 base 패턴에 기반했는지 (flat_base / cup_with_handle / cup_without_handle / vcp / double_bottom / 3c_cheat).", constraint: "exactly one of: flat_base, cup_with_handle, cup_without_handle, vcp, double_bottom, 3c_cheat" },
   { name: "entry_window_days", category: "guard", what: "트리거 발생 후 며칠 안에 진입해야 유효한가 (1~5 일).", constraint: "integer, 1 ~ 5" },
   { name: "max_chase_pct_from_pivot", category: "guard", what: "pivot 위로 최대 몇 %까지 추격 매수 허용 (O'Neil: ≤5%).", constraint: "0.0 ~ 5.0%" },
-  { name: "breakout_volume_requirement", category: "guard", what: "돌파일 거래량 요건 (1.4× / 1.5× 50일평균 / pocket pivot signature).", constraint: "exactly one of: ge_1.3x_50day_avg, ge_1.4x_50day_avg, ge_1.5x_50day_avg, pocket_pivot_signature" },
+  { name: "breakout_volume_requirement", category: "guard", what: "돌파일 거래량 요건 (1.4× / 1.5× 50일평균 / strict 1.5×(#74 cup_without_handle) / pocket pivot signature).", constraint: "exactly one of: ge_1.3x_50day_avg, ge_1.4x_50day_avg, ge_1.5x_50day_avg, ge_1.5x_strict, pocket_pivot_signature" },
   { name: "observed_breakout_volume_ratio", category: "guard", what: "실제 관측된 거래량 비율 — null 또는 0.0-20.0× 사이.", constraint: "null OR 0.0 ~ 20.0" },
 
   // Meta 메타 (3)

--- a/web/src/data/llm-pipeline/glossary.ts
+++ b/web/src/data/llm-pipeline/glossary.ts
@@ -15,7 +15,7 @@ export const GLOSSARY: GlossaryEntry[] = [
   // ─── 책 용어 — 패턴·매수 기준 ───
   { term: "Trend Template (8조건)", meaning: "Minervini *TLSMW Ch.5* 의 강세 종목 식별 8 기준. 가격이 SMA-50/150/200 위, SMA 정렬, 200일선 상승 추세, 52주 고점 25% 이내, 52주 저점 25% 이상, RS Rating ≥70 등. 시스템의 1차 결정론 필터." },
   { term: "RS Rating", meaning: "Relative Strength Rating (상대 강도). 전체 종목 대비 가격 상승률의 백분위 (0-99). 70 이상이 책 기준 (Minervini), 80+ 가 O'Neil 선호. 같은 종목 풀 안에서의 *상대* 측정." },
-  { term: "base (베이스)", meaning: "주가가 옆으로 정리되는 구간 — 컵·평평한 박스·VCP·이중바닥 등 9 종. 돌파 전의 매수 준비 단계." },
+  { term: "base (베이스)", meaning: "주가가 옆으로 정리되는 구간 — 컵·평평한 박스·VCP·이중바닥 등 10 종. 돌파 전의 매수 준비 단계." },
   { term: "pivot (피벗)", meaning: "책에서 권하는 *정확한 매수 기준가*. 패턴별로 다르게 정의 — cup_with_handle 은 손잡이 고점, flat_base 는 범위 상단 등." },
   { term: "breakout (돌파)", meaning: "종가가 pivot 위로 올라간 사건. 거래량 동반이면 진짜 돌파, 아니면 가짜 돌파 가능성." },
   { term: "pocket pivot (포켓 피벗)", meaning: "Morales/Kacher *TLOND Ch.5* 의 *조기 매수 신호*. base 안에서 거래량이 직전 10일 중 하락일 최대 거래량을 초과 + 종가가 SMA-50 위. 표준 pivot 돌파 *전* 의 매수 기회." },
@@ -80,7 +80,7 @@ export const GLOSSARY_MAP: Record<string, string> = (() => {
     ["breakout", "종가가 pivot 위로 올라간 사건. 거래량 동반이면 진짜 돌파."],
     ["promotion", "watch 종목이 pivot 의 95% 까지 도달 — 돌파 직전 staging."],
     ["invalidation", "base 무효화 — 종가가 손절선/SMA-50 아래로."],
-    ["base", "주가가 옆으로 정리되는 구간 — 컵·평평한 박스·VCP 등 9 종."],
+    ["base", "주가가 옆으로 정리되는 구간 — 컵·평평한 박스·VCP 등 10 종."],
     ["Stage 2", "Minervini 의 종목 사이클 4 단계 중 *기관 누적 + 상승* 구간. 매수 적기."],
     ["distribution day", "기관 매도일 — 시장 지수 ≥0.2% 하락 + 거래량 전일보다 증가."],
     ["FTD", "Follow-Through Day — 조정 끝 강세 전환 확인 신호."],

--- a/web/src/data/llm-pipeline/prompt-explanations.ts
+++ b/web/src/data/llm-pipeline/prompt-explanations.ts
@@ -93,7 +93,7 @@ export const PROMPT_EXPLANATIONS: Record<string, PromptExplanation> = {
       "**Minervini 1-3% per trade**: suggested_weight_pct 는 포트폴리오의 1-3% *위험* 한도 안에서 산출. 손절 폭이 크면 포지션 작게, 손절 폭이 좁으면 포지션 크게.",
       "**5% chase 한계**: max_chase_pct_from_pivot ≤ 5% — pivot 위로 5% 넘게 올라간 종목은 추격 매수 금지 (O'Neil HMMS Ch.10). 현행 결정론 함수는 VCP 를 일괄 3% 로 더 보수화 (#21 D3a).",
       "**entry_mode 별 다른 룰**: pivot_breakout 은 표준 손절·사이징·거래량 1.4-1.5×. pocket_pivot 은 더 타이트 (손절 -5.5%~-4.5%, 거래량 1.0× 가능).",
-      "**책 표준 거래량**: standard pivot_breakout 의 breakout_volume_requirement 디폴트 = ge_1.5x_50day_avg (책 선호치 50%+). 관측값 1.4×~1.5% 면 known_warning emit + 진입 허용.",
+      "**책 표준 거래량**: standard pivot_breakout 의 breakout_volume_requirement 디폴트 = ge_1.5x_50day_avg (책 선호치 50%+). 관측값 1.4×~1.5% 면 known_warning emit + 진입 허용. (cup_without_handle 은 예외 — strict 1.5× 미만은 진입 불가, #74)",
       "**known_warnings 화이트리스트**: 16 종 정의된 경고 코드만 사용. 자유 텍스트 경고는 other_warnings 로. 현행 결정론 함수는 이 중 11 종만 발행 가능 (나머지 4+1 종은 #21 결정으로 발행 지점 소멸).",
     ],
   },

--- a/web/src/data/llm-pipeline/prompt-explanations.ts
+++ b/web/src/data/llm-pipeline/prompt-explanations.ts
@@ -25,7 +25,7 @@ export const PROMPT_EXPLANATIONS: Record<string, PromptExplanation> = {
     ],
     output: [
       "classification: entry / watch / ignore 중 하나",
-      "pattern: 9 종 base 패턴 (flat_base, cup_with_handle, vcp 등) 중 하나 또는 none",
+      "pattern: 10 종 base 패턴 (flat_base, cup_with_handle, cup_without_handle, vcp 등) 중 하나 또는 none",
       "pivot_price: 책 정의 매수 기준가 (패턴별 정의 다름)",
       "base_depth_pct: base 깊이 (peak 대비 trough)",
       "risk_flags: 13 종 위험 신호 중 부분집합 (climax_run·late_stage_base·faulty_pivot 등)",
@@ -34,7 +34,7 @@ export const PROMPT_EXPLANATIONS: Record<string, PromptExplanation> = {
     ],
     keyRules: [
       "**책 정통 추세주만 entry**: Stage 2 진입 + 깨끗한 base + 시장 우호적 시점 (§3.5 의 4-enum 시장 상태가 confirmed_uptrend) — 모두 만족해야 entry. 하나라도 빠지면 watch 또는 ignore.",
-      "**9 base 패턴만 허용**: flat_base / cup_with_handle / vcp / double_bottom / high_tight_flag / 3c_cheat / base_on_base / ascending_base / none. 책에 없는 패턴은 추측 금지 — none 으로 처리.",
+      "**10 base 패턴만 허용**: flat_base / cup_with_handle / cup_without_handle / vcp / double_bottom / high_tight_flag / 3c_cheat / base_on_base / ascending_base / none. 책에 없는 패턴은 추측 금지 — none 으로 처리.",
       "**13 risk flag 분류**: 위험 신호도 고정 13 종 목록만 사용. 자유 표현 금지. UI 와 prompt 가 동일한 분류 체계 공유.",
       "**시장 컨텍스트 하드룰** (§3.5): 시장이 correction/downtrend 면 entry 불가 → watch 강제. 시장 distribution day ≥ 5 이면 confidence -0.15.",
       "**handle 품질 (cup_with_handle)**: handle 깊이 8-12% / 10주 MA 위 / wedging 금지 — O'Neil HMMS p.116. 위반 시 watch 강등.",

--- a/web/src/data/llm-pipeline/tables.ts
+++ b/web/src/data/llm-pipeline/tables.ts
@@ -107,7 +107,7 @@ export const TABLES: Record<string, TableInfo> = {
     keyColumns: [
       "classification ('entry' / 'watch' / 'ignore')",
       "confidence (0.0-1.0)",
-      "pattern (9 base 패턴 중 하나)",
+      "pattern (10 base 패턴 중 하나)",
       "pivot_price (책 정의 매수 기준가)",
       "base_depth_pct (base 깊이 %)",
       "risk_flags (JSONB, 13 risk flag 중 부분집합)",

--- a/web/src/pages/ClassificationsPage.tsx
+++ b/web/src/pages/ClassificationsPage.tsx
@@ -67,6 +67,8 @@ const PATTERN_DESCRIPTIONS: Record<string, string> = {
     "5~7주 횡보 통합, depth ≤15% — Cup-with-handle 이후 자주 등장하는 2차 base (Box 형태).",
   cup_with_handle:
     "U자 컵 (12~33% 조정, 깊으면 50%까지) + cup 상반부에 형성된 짧은 손잡이 (8~12% pullback), 7주~수개월. O'Neil 의 가장 흔한 정통 패턴.",
+  cup_without_handle:
+    "U자 컵 (기준은 cup_with_handle 과 동일) — 손잡이 없이 컵 고점 돌파를 노리는 패턴 (O'Neil 5대 모델). 우측이 고점의 90%까지 회복돼야 인정. 보수 장치: 돌파 거래량 strict 1.5× + 사이징 감액 (#74).",
   vcp:
     "Volatility Contraction Pattern — 변동성과 거래량이 단계적으로 줄어드는 통합 (Minervini).",
   double_bottom:

--- a/web/src/pages/LlmPipelineAuditPage.tsx
+++ b/web/src/pages/LlmPipelineAuditPage.tsx
@@ -44,7 +44,7 @@ export default function LlmPipelineAuditPage() {
         </h1>
         <p className="text-data text-muted mt-3 leading-relaxed">
           Minervini / O'Neil 책 전문가가 한 페이지만 보고 시스템 전체
-          (스케줄링 / 5 stage / Minervini 8조건 / 9 base 패턴 / 13 risk_flag /
+          (스케줄링 / 5 stage / Minervini 8조건 / 10 base 패턴 / 13 risk_flag /
           ZIP 13 / 3 prompt / 변경 이력) 를 line-by-line 검증할 수 있는 페이지.
         </p>
       </header>
@@ -67,7 +67,7 @@ export default function LlmPipelineAuditPage() {
             <div className="text-ink font-semibold mb-2">무엇을 볼 수 있나요?</div>
             <ul className="space-y-1.5 list-disc list-inside pl-1">
               <li><span className="text-ink">Minervini Trend Template 8 조건</span> — 추세 강도를 판정하는 8 기준 (이동평균 배열, 신고가 근접 등).</li>
-              <li><span className="text-ink">9 base 패턴 정의</span> — flat_base · cup_with_handle · VCP · double_bottom 등 책이 정의한 모든 base 모양.</li>
+              <li><span className="text-ink">10 base 패턴 정의</span> — flat_base · cup_with_handle · cup_without_handle · VCP · double_bottom 등 책이 정의한 모든 base 모양.</li>
               <li><span className="text-ink">13 risk flag</span> — 매수 적합도를 깎는 위험 신호 (climax_run · late_stage_base · faulty_pivot 등).</li>
               <li><span className="text-ink">3 prompt 본문 전체</span> — AI 가 실제로 받는 지시문 (analyze_chart_v3 / evaluate_pivot_trigger / calculate_entry_params).</li>
               <li><span className="text-ink">변경 이력</span> — 룰이 언제·왜·어떻게 바뀌었는지 letter 별 (A, B, ..., K) 추적.</li>
@@ -88,7 +88,7 @@ export default function LlmPipelineAuditPage() {
             <ul className="space-y-1.5 list-disc list-inside pl-1">
               <li><span className="text-ink">prompt</span> — AI 에게 주는 지시문 (예: <em>"이 차트를 분석해 entry/watch/ignore 중 하나로 분류해줘"</em>). 본 시스템은 3 prompt 사용.</li>
               <li><span className="text-ink">risk flag</span> — 매수에 부적합한 위험 신호. 13 종 고정 목록만 사용.</li>
-              <li><span className="text-ink">base 패턴</span> — 주가가 옆으로 정리되는 모양. 9 종 분류.</li>
+              <li><span className="text-ink">base 패턴</span> — 주가가 옆으로 정리되는 모양. 10 종 분류.</li>
               <li><span className="text-ink">book quote / English quote</span> — 룰의 책 원문 인용. "Why" 를 책 페이지·문장 단위로 추적 가능.</li>
             </ul>
           </div>

--- a/web/src/pages/LlmPipelinePage.tsx
+++ b/web/src/pages/LlmPipelinePage.tsx
@@ -71,7 +71,7 @@ const STAGES: PipelineStage[] = [
     deterministicDetail:
       "SQL 조건:\n  WHERE minervini_pass = TRUE\n    AND stocks.delisted_at IS NULL\n\n기준 행: 직전 금요일자 daily_indicators.\ncron 시각: 토 03:20 KST.\n\n💡 minervini_pass 컬럼은 daily_indicators 가 적재될 때 함께 계산 — 8 조건 모두 충족 시에만 TRUE (아래 '8 조건 모두 보기' fold 참조).",
     llmSummary:
-      "각 종목별로 13 개의 파일이 든 ZIP 묶음 (차트 PNG·일/주봉 OHLCV·시장 컨텍스트·corporate actions·minervini 진단 등) 을 만들어 AI 에게 보내고, analyze_chart_v3.md prompt 의 지시를 따라 '[[base]] 패턴 + risk flag + 분류' 를 받습니다. AI 는 9 종 [[base]] 패턴과 13 종 risk flag 만 사용하도록 제약돼 있습니다.",
+      "각 종목별로 13 개의 파일이 든 ZIP 묶음 (차트 PNG·일/주봉 OHLCV·시장 컨텍스트·corporate actions·minervini 진단 등) 을 만들어 AI 에게 보내고, analyze_chart_v3.md prompt 의 지시를 따라 '[[base]] 패턴 + risk flag + 분류' 를 받습니다. AI 는 10 종 [[base]] 패턴과 13 종 risk flag 만 사용하도록 제약돼 있습니다.",
     llmShowsLists: {
       eightConditions: true,
       thirteenZipFiles: true,
@@ -458,7 +458,7 @@ function StageCard({ stage }: { stage: PipelineStage }) {
               </ListFold>
             )}
             {stage.llmShowsLists?.nineBasePatterns && (
-              <ListFold label="AI 가 식별하는 9 base 패턴 모두 보기" count={BASE_PATTERNS.length}>
+              <ListFold label="AI 가 식별하는 10 base 패턴 모두 보기" count={BASE_PATTERNS.length}>
                 <ul className="space-y-2">
                   {BASE_PATTERNS.map((p) => (
                     <li key={p.id}>
@@ -686,7 +686,7 @@ export default function LlmPipelinePage() {
             <ul className="space-y-1.5 list-disc list-inside pl-1">
               <li><span className="text-ink">결정론</span> — 사람이 미리 정한 명확한 룰 (예: <em>"거래량이 평균 이상이어야 통과"</em>).</li>
               <li><span className="text-ink">LLM (AI)</span> — 차트·지표·뉴스 등을 받아 판단하는 AI 모델. <em>"이 종목은 entry / watch / ignore"</em> 같은 결정을 내림.</li>
-              <li><span className="text-ink">base 패턴</span> — 주가가 옆으로 가다가 돌파 직전인 <em>모양</em> (컵·평평한 박스·VCP 등 9 종).</li>
+              <li><span className="text-ink">base 패턴</span> — 주가가 옆으로 가다가 돌파 직전인 <em>모양</em> (컵·평평한 박스·VCP 등 10 종).</li>
               <li><span className="text-ink">Minervini / O'Neil</span> — 본 시스템이 따르는 두 미국 성장주 투자 대가. 룰 대부분이 그들의 책에서 옴.</li>
             </ul>
           </div>


### PR DESCRIPTION
## 개요

책-충실성 검토 2회 연속 지적(F7→F1)의 이행 — **cup_without_handle 을 정식 taxonomy 로 수용**(외부 red-team A 권고, 사용자 확정 07-22)하되, 보수 장치 2개와 실패 시 자동 회귀 기준(사전등록 F1~F4)을 함께 배포한다. **원자 배포**: 프롬프트+코드+web 동기가 단일 PR — 분리 배포 시 보수 장치 없이 라이브 노출되는 창이 생기므로 금지(스펙 헤더 명문).

## 변경 내용

- **taxonomy·Gate3**: `prompts/analyze_chart_v3.md` — §4 정의 행(컵 기준은 cup_with_handle 동일, 핸들 없음 — HMMS 5대 모델, book-mandated), Gate3 분기(핸들 <5일 + **우측 회복 완료**(최고 종가 ≥ cup high×0.90, 도달치 래칫) → 신 패턴·pivot=컵 절대 고점 / 미완 → base_forming 구 라벨 연속), §4.7 pivot 표 + `pivot_basis=cup_high`(store +tick 검증 편입), :540 재작성, §4.5 PP 의도적 제외, 9→10 카운트
- **보수 장치 ⓐ**: `evaluate_pivot.py` 결정론 인터셉트 — 체인 **dedupe → extended(#45) → strict 1.5×**(grace band 비허용, `wait_reason='volume_below_strict_no_handle'` — F4 코호트 키). §8 각주는 "돌파를 근거로 entry 판정할 때에 한해" 스코프 한정
- **보수 장치 ⓑ**: `entry_params_calc.py` — `no_handle_shakeout_absent` flag 결정론 주입(멱등) → 실효 **4.9pp**(fallback 7.0×0.7, 이중 페널티 수용 — 구조 재검토는 #80)
- **보유 억제(dedupe)**: 상향 트리거(breakout·bfw·promotion)만 억제(`suppressed_position_held`), **invalidation(손절 신호)은 절대 비억제**
- **사전등록 F1~F4**: 외부 검토 원문 불변 등록 + 측정 규약 부록(체결/신호 코호트 이중 정의, F1 손절가=entry_params 실값, F4 경로 비대칭 병행 보고) — `docs/superpowers/specs/2026-07-24-issue74-cup-without-handle.md` §6
- **의존성 맵**: 상수별 11행 2축 판정(GATE_PROMOTION_PRICE_RATIO·ENTRY_WEIGHT_PCT_MIN 포함) — threshold-change-checklist 게이트 5조건 충족
- **web 동기 12개소** + `remeasure_phase2i.py` superseded 주석

## 리뷰

독립 리뷰 3회(설계: 차단 5·비차단 7 / 스펙: 차단 2+자체 1·권고 8 / 구현: 차단 1·권고 5) — 전 항목 반영. 주요 수리: 인터셉트 지점 교정(gate_precompute→evaluate_pivot), 사이징 전제 수치 정정(3.5→4.9pp), 회복 경계 정량화(0.90 래칫), 손절 신호 비억제 명문화, F1~F4 판정 가능화.

## 관련 이슈

Closes #74 (F1~F4 판독은 코호트 크기 도달 시 — measurement-based)

## 테스트

- [x] `uv run pytest tests/` — **1123 passed / 0 failed** (신규 21종: 인터셉트 체인·사이징·프롬프트 텍스트 고정)
- [x] web `npm run build` 통과
- [x] 비변경 확인: Gate2 V 배제·발화 임계·타 패턴 경로·`thresholds.py`(신설 상수 0)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
